### PR TITLE
avoid dup iptables rules

### DIFF
--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -19,10 +19,13 @@ fi
 
 # Setup NAT forwarding if requested
 if [ "$OVPN_DEFROUTE" != "0" ];then
-    iptables -t nat -A POSTROUTING -s $OVPN_SERVER -o eth0 -j MASQUERADE
-
+    iptables -t nat -C POSTROUTING -s $OVPN_SERVER -o eth0 -j MASQUERADE || {
+      iptables -t nat -A POSTROUTING -s $OVPN_SERVER -o eth0 -j MASQUERADE
+    }
     for i in "${OVPN_ROUTES[@]}"; do
-        iptables -t nat -A POSTROUTING -s "$i" -o eth0 -j MASQUERADE
+        iptables -t nat -C POSTROUTING -s "$i" -o eth0 -j MASQUERADE || {
+          iptables -t nat -A POSTROUTING -s "$i" -o eth0 -j MASQUERADE
+        }
     done
 fi
 


### PR DESCRIPTION
Thanks for creating this!

I realized during my testing that the iptables rules where getting duplicated on every ovpn_run call. This should fix that! They will only be created if they don't exist already.
