### PR TITLE
no connection block in client config

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -37,9 +37,7 @@ $(cat $EASYRSA_PKI/ta.key)
 </tls-auth>
 key-direction 1
 
-<connection>
 remote $OVPN_CN $OVPN_PORT $OVPN_PROTO
-</connection>
 EOF
 
 if [ "$OVPN_DEFROUTE" != "0" ];then


### PR DESCRIPTION
The android app **OpenVPN for Android** doen't supports `<connection>` blocks in the client configuration file. Because the generated config only use a single `remote` config I have removed the block.
I can confirm, [OpenVPN Connect](https://play.google.com/store/apps/details?id=net.openvpn.openvpn) can still import and connect with the clienet config without `<connection>`.
- App: https://play.google.com/store/apps/details?id=de.blinkt.openvpn
- Source: https://code.google.com/p/ics-openvpn/source/checkout (uses OpenVPN 2.3)
