### PR TITLE
Fixed SIGTERM handling

### DIFF
--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -31,4 +31,4 @@ fi
 
 conf="$OPENVPN/openvpn.conf"
 
-openvpn --config "$conf"
+exec openvpn --config "$conf"


### PR DESCRIPTION
This fixes SIGTERM handling when stopping the docker container so openvpn will properly cleanup the interface.
