### PR TITLE
Run daemon as nobody

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -150,6 +150,9 @@ dev tun0
 status /tmp/openvpn-status.log
 
 client-config-dir $OPENVPN/ccd
+
+user nobody
+group nogroup
 EOF
 
 [ -n "$OVPN_CLIENT_TO_CLIENT" ] && echo "client-to-client" >> "$conf"


### PR DESCRIPTION
Always good practice to give up root privileges after initial setup.  Docker is [not secure](https://docs.docker.com/articles/security/) when running as root.