### PR TITLE
Return correct exit status in ovpn_getclient script

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -44,4 +44,6 @@ if [ "$OVPN_DEFROUTE" != "0" ];then
     echo "redirect-gateway def1"
 fi
 
-[ -n "$OVPN_MTU" ] && echo "tun-mtu $OVPN_MTU"
+if [ -n "$OVPN_MTU" ]; then
+    echo "tun-mtu $OVPN_MTU"
+fi


### PR DESCRIPTION
if the length of $OVPN_MTU is zero, the script will exit with 1 rather than 0