### PR TITLE
Disable default bash xtrace and fix but in variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Upstream links:
 
         docker run --volumes-from $OVPN_DATA --rm kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
 
+* Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
+
+        for example - docker run --volumes-from $OVPN_DATA -d -p 1194:1194/udp --privileged -e DEBUG=1 kylemanna/openvpn
 
 ## How Does It Work?
 

--- a/bin/easyrsa_vars
+++ b/bin/easyrsa_vars
@@ -4,7 +4,11 @@
 # Import/export EasyRSA default settings
 #
 
-set -ex
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
+set -e
 
 if [ $# -lt 1 ]; then
     echo "No command provided"

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -58,7 +58,9 @@ OVPN_DEFROUTE=1
 OVPN_NAT=0
 OVPN_DNS=1
 OVPN_ROUTES=()
+TMP_ROUTES=()
 OVPN_PUSH=()
+TMP_PUSH=()
 
 # Import defaults if present
 [ -r "$OVPN_ENV" ] && source "$OVPN_ENV"
@@ -67,7 +69,7 @@ OVPN_PUSH=()
 while getopts ":r:s:du:cp:DNm:" opt; do
     case $opt in
         r)
-            OVPN_ROUTES+=("$OPTARG")
+            TMP_ROUTES+=("$OPTARG")
             ;;
         s)
             OVPN_SERVER=$OPTARG
@@ -82,7 +84,7 @@ while getopts ":r:s:du:cp:DNm:" opt; do
             OVPN_CLIENT_TO_CLIENT=1
             ;;
         p)
-            OVPN_PUSH+=("$OPTARG")
+            TMP_PUSH+=("$OPTARG")
             ;;
         D)
             OVPN_DNS=0
@@ -108,6 +110,11 @@ while getopts ":r:s:du:cp:DNm:" opt; do
     esac
 done
 
+# if new routes were not defined with -r, use default
+[ ${#TMP_ROUTES[@]} -gt 0 ] && OVPN_ROUTES=${TMP_ROUTES[@]}
+
+# if new push directives were not defined with -p, use default
+[ ${#TMP_PUSH[@]} -gt 0 ] && OVPN_PUSH=${TMP_PUSH[@]}
 
 # Server name is in the form "udp://vpn.example.com:1194"
 if [[ "$OVPN_SERVER_URL" =~ ^((udp|tcp)://)?([0-9a-zA-Z\.\-]+)(:([0-9]+))?$ ]]; then

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -111,10 +111,10 @@ while getopts ":r:s:du:cp:DNm:" opt; do
 done
 
 # if new routes were not defined with -r, use default
-[ ${#TMP_ROUTES[@]} -gt 0 ] && OVPN_ROUTES=${TMP_ROUTES[@]}
+[ ${#TMP_ROUTES[@]} -gt 0 ] && OVPN_ROUTES=("${TMP_ROUTES[@]}")
 
 # if new push directives were not defined with -p, use default
-[ ${#TMP_PUSH[@]} -gt 0 ] && OVPN_PUSH=${TMP_PUSH[@]}
+[ ${#TMP_PUSH[@]} -gt 0 ] && OVPN_PUSH=("${TMP_PUSH[@]}")
 
 # Server name is in the form "udp://vpn.example.com:1194"
 if [[ "$OVPN_SERVER_URL" =~ ^((udp|tcp)://)?([0-9a-zA-Z\.\-]+)(:([0-9]+))?$ ]]; then

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -46,7 +46,11 @@ usage() {
     echo " -m    Set client MTU"
 }
 
-set -ex
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
+set -e
 
 OVPN_ENV=$OPENVPN/ovpn_env.sh
 OVPN_SERVER=192.168.255.0/24

--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -4,7 +4,11 @@
 # Get an OpenVPN client configuration file
 #
 
-set -ex
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
+set -e
 
 source "$OPENVPN/ovpn_env.sh"
 cn=$1

--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -4,7 +4,11 @@
 # Initialize the EasyRSA PKI
 #
 
-set -ex
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
+set -e
 
 source "$OPENVPN/ovpn_env.sh"
 

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -4,7 +4,11 @@
 # Run the OpenVPN server normally
 #
 
-set -ex
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
+
+set -e
 
 source "$OPENVPN/ovpn_env.sh"
 

--- a/bin/ovpn_status
+++ b/bin/ovpn_status
@@ -3,7 +3,10 @@
 #
 # Get OpenVPN server status
 #
+if [ "$DEBUG" == "1" ]; then
+  set -x
+fi
 
-set -ex
+set -e
 
 tail -F /tmp/openvpn-status.log


### PR DESCRIPTION
Two changes in this pull request -
1. disable default bash xtrace with option to enable with DEBUG environment variable.
2. fix a bug that caused accumulation of routes and push directives when ovpn_genconfig was used multiple times.