### PR TITLE
Optimized ovpn_copy_server_files script. No need to copy the config files.

### DIFF
--- a/bin/ovpn_copy_server_files
+++ b/bin/ovpn_copy_server_files
@@ -17,18 +17,15 @@ else
     TARGET="$OPENVPN/server"
 fi
 
-rsync --recursive --verbose --prune-empty-dirs \
-    --exclude="clients" \
-    --exclude="server" \
-    --include "*/" \
-    --include "/pki/private/${OVPN_CN}.key" \
-    --include "/pki/ca.crt" \
-    --include "/pki/issued/${OVPN_CN}.crt" \
-    --include "/pki/dh.pem" \
-    --include "ta.key" \
-    --include "/openvpn.conf" \
-    --include "/ovpn_env.sh" \
-    --exclude="*" \
+echo "
+pki/private/${OVPN_CN}.key
+pki/issued/${OVPN_CN}.crt
+pki/dh.pem
+pki/ta.key
+pki/ca.crt
+" | rsync --recursive --verbose \
+    --files-from - \
     "$OPENVPN/" "$TARGET"
+ln --symbolic --force ../openvpn.conf ../ovpn_env.sh "$TARGET"
 
 echo "Created the openvpn configuration for the server: $TARGET"


### PR DESCRIPTION
* rsync can copy the actual files.
* This change makes it easier to modifier the configuration and sync it
  to the server. You only have to execute the ovpn_copy_server_files
  once.