### PR TITLE
Create ccd directory to prevent error if /etc is mounted read-only.

### DIFF
--- a/bin/ovpn_copy_server_files
+++ b/bin/ovpn_copy_server_files
@@ -27,5 +27,6 @@ pki/ca.crt
     --files-from - \
     "$OPENVPN/" "$TARGET"
 ln --symbolic --force ../openvpn.conf ../ovpn_env.sh "$TARGET"
+mkdir -p "$TARGET/ccd"
 
 echo "Created the openvpn configuration for the server: $TARGET"


### PR DESCRIPTION
* mkdir: cannot create directory '/etc/openvpn/ccd': Read-only file system