### PR TITLE
Remove dh param from client config

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -50,9 +50,6 @@ $(cat $EASYRSA_PKI/issued/${cn}.crt)
 <ca>
 $(cat $EASYRSA_PKI/ca.crt)
 </ca>
-<dh>
-$(cat $EASYRSA_PKI/dh.pem)
-</dh>
 <tls-auth>
 $(cat $EASYRSA_PKI/ta.key)
 </tls-auth>
@@ -63,7 +60,6 @@ key-direction 1
 key ${cn}.key
 ca ca.crt
 cert ${cn}.crt
-dh dh.pem
 tls-auth ta.key 1
 $OVPN_ADDITIONAL_CLIENT_CONFIG
 "
@@ -86,7 +82,6 @@ case "$parm" in
         cp "$EASYRSA_PKI/private/${cn}.key" "$dir/${cn}.key"
         cp "$EASYRSA_PKI/ca.crt" "$dir/ca.crt"
         cp "$EASYRSA_PKI/issued/${cn}.crt" "$dir/${cn}.crt"
-        cp "$EASYRSA_PKI/dh.pem" "$dir/dh.pem"
         cp "$EASYRSA_PKI/ta.key" "$dir/ta.key"
         ;;
     "" | "combined")


### PR DESCRIPTION
The dh param is intended for servers. From the manpage:

```
--dh file
File containing Diffie Hellman parameters in .pem format (required for --tls-server only).
```

Including this parameter causes some clients to barf, [including Viscosity](http://www.sparklabs.com/forum/viewtopic.php?f=3&t=817).