### PR TITLE
Add a parameter to use TAP instead of TUN device.

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -44,6 +44,7 @@ usage() {
     echo " -D    Disable built in external dns (google dns)"
     echo " -N    Configure NAT to access external server network"
     echo " -m    Set client MTU"
+    echo " -t    Use TAP device (instead of TUN device)"
 }
 
 if [ "$DEBUG" == "1" ]; then
@@ -57,6 +58,8 @@ OVPN_SERVER=192.168.255.0/24
 OVPN_DEFROUTE=1
 OVPN_NAT=0
 OVPN_DNS=1
+OVPN_DEVICE="tun"
+OVPN_DEVICEN=0
 OVPN_ROUTES=()
 TMP_ROUTES=()
 OVPN_PUSH=()
@@ -66,7 +69,7 @@ TMP_PUSH=()
 [ -r "$OVPN_ENV" ] && source "$OVPN_ENV"
 
 # Parse arguments
-while getopts ":r:s:du:cp:DNm:" opt; do
+while getopts ":r:s:du:cp:DNm:t" opt; do
     case $opt in
         r)
             TMP_ROUTES+=("$OPTARG")
@@ -94,6 +97,9 @@ while getopts ":r:s:du:cp:DNm:" opt; do
             ;;
         m)
             OVPN_MTU=$OPTARG
+            ;;
+        t)
+            OVPN_DEVICE="tap"
             ;;
         \?)
             set +x
@@ -135,7 +141,7 @@ fi
 
 export OVPN_SERVER OVPN_ROUTES OVPN_DEFROUTE
 export OVPN_SERVER_URL OVPN_ENV OVPN_PROTO OVPN_CN OVPN_PORT
-export OVPN_CLIENT_TO_CLIENT OVPN_PUSH OVPN_NAT OVPN_DNS OVPN_MTU
+export OVPN_CLIENT_TO_CLIENT OVPN_PUSH OVPN_NAT OVPN_DNS OVPN_MTU OVPN_DEVICE
 
 # Preserve config
 if [ -f "$OVPN_ENV" ]; then
@@ -168,7 +174,7 @@ persist-tun
 proto $OVPN_PROTO
 # Rely on Docker to do port mapping, internally always 1194
 port 1194
-dev tun0
+dev $OVPN_DEVICE$OVPN_DEVICEN
 status /tmp/openvpn-status.log
 
 user nobody
@@ -191,7 +197,7 @@ for i in "${OVPN_PUSH[@]}"; do
     echo push \"$i\" >> "$conf"
 done
 
-set +e 
+set +e
 
 # Clean-up duplicate configs
 if diff -q "$bak_env" "$OVPN_ENV" 2>/dev/null; then

--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -34,7 +34,7 @@ get_client_config() {
     echo "
 client
 nobind
-dev tun
+dev $OVPN_DEVICE
 remote-cert-tls server
 
 remote $OVPN_CN $OVPN_PORT $OVPN_PROTO


### PR DESCRIPTION
This creates an additional parameter (```-t```) for ```ovpn_genconfig``` to use a tap device instead of a tun device. This change is in turn also included in the generated client configurations.