### PR TITLE
Set custom OVPN_NATDEVICE when using --net=host to custom interface.

### DIFF
--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -24,14 +24,17 @@ if [ -d "$OPENVPN/ccd" ]; then
     ARGS+=("--client-config-dir" "$OPENVPN/ccd")
 fi
 
+# When using --net=host, use this to specify nat device.
+[ -z "$OVPN_NATDEVICE" ] && OVPN_NATDEVICE=eth0
+
 # Setup NAT forwarding if requested
 if [ "$OVPN_DEFROUTE" != "0" ] || [ "$OVPN_NAT" == "1" ] ; then
-    iptables -t nat -C POSTROUTING -s $OVPN_SERVER -o eth0 -j MASQUERADE || {
-      iptables -t nat -A POSTROUTING -s $OVPN_SERVER -o eth0 -j MASQUERADE
+    iptables -t nat -C POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE || {
+      iptables -t nat -A POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE
     }
     for i in "${OVPN_ROUTES[@]}"; do
-        iptables -t nat -C POSTROUTING -s "$i" -o eth0 -j MASQUERADE || {
-          iptables -t nat -A POSTROUTING -s "$i" -o eth0 -j MASQUERADE
+        iptables -t nat -C POSTROUTING -s "$i" -o $OVPN_NATDEVICE -j MASQUERADE || {
+          iptables -t nat -A POSTROUTING -s "$i" -o $OVPN_NATDEVICE -j MASQUERADE
         }
     done
 fi


### PR DESCRIPTION
There are systems where eth0 does not exist in combination with "--net=host"

For example on an host system with an interface `enp0s25` you would use this like so:

    docker run --volumes-from ovpn-data --net=host --rm=true -p 1194:1194/udp -e OVPN_NATDEVICE=enp0s25 --cap-add=NET_ADMIN wernerb/openvpn