### PR TITLE
ovpn_copy_server_files: Ensure that no other keys then the one for the server is present.

### DIFF
--- a/bin/ovpn_copy_server_files
+++ b/bin/ovpn_copy_server_files
@@ -17,6 +17,9 @@ else
     TARGET="$OPENVPN/server"
 fi
 
+## Ensure that no other keys then the one for the server is present.
+rm --recursive --force "$TARGET/pki/private" "$TARGET/pki/issued"
+
 echo "
 pki/private/${OVPN_CN}.key
 pki/issued/${OVPN_CN}.crt


### PR DESCRIPTION
When creating a multi-server setup I used a partly copied, partly
symlinked directory structure for the different servers after creating a
certificate for each server with `easyrsa build-server-full`. In that
process I also copied the `server` directory.
The rsync command does not delete files which are not excluded so it
included the correct server key and the original one which can be a
security risk.