### PR TITLE
Only setup networking for containers which need it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ a corresponding [Digital Ocean Community Tutorial](http://bit.ly/1AGUZkq).
 
 * Create the `$OVPN_DATA` volume container, i.e. `OVPN_DATA="ovpn-data"`
 
-        docker run --name $OVPN_DATA -v /etc/openvpn busybox
+        docker run --name $OVPN_DATA --net=none -v /etc/openvpn busybox
 
 * Initialize the `$OVPN_DATA` container that will hold the configuration files and certificates
 
-        docker run --volumes-from $OVPN_DATA --rm kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
-        docker run --volumes-from $OVPN_DATA --rm -it kylemanna/openvpn ovpn_initpki
+        docker run --volumes-from $OVPN_DATA --net=none --rm kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
+        docker run --volumes-from $OVPN_DATA --net=none --rm -it kylemanna/openvpn ovpn_initpki
 
 * Start OpenVPN server process
 
@@ -37,11 +37,11 @@ a corresponding [Digital Ocean Community Tutorial](http://bit.ly/1AGUZkq).
 
 * Generate a client certificate without a passphrase
 
-        docker run --volumes-from $OVPN_DATA --rm -it kylemanna/openvpn easyrsa build-client-full CLIENTNAME nopass
+        docker run --volumes-from $OVPN_DATA --net=none --rm -it kylemanna/openvpn easyrsa build-client-full CLIENTNAME nopass
 
 * Retrieve the client configuration with embedded certificates
 
-        docker run --volumes-from $OVPN_DATA --rm kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
+        docker run --volumes-from $OVPN_DATA --net=none --rm kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
 
 * Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,11 +9,11 @@ The [`ovpn_genconfig`](/bin/ovpn_genconfig) script is intended for simple config
 
         mkdir openvpn0
         cd openvpn0
-        docker run --rm -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM:1194
-        docker run --rm -v $PWD:/etc/openvpn -it kylemanna/openvpn ovpn_initpki
+        docker run --net=none --rm -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM:1194
+        docker run --net=none --rm -v $PWD:/etc/openvpn -it kylemanna/openvpn ovpn_initpki
         vim openvpn.conf
-        docker run --rm -v $PWD:/etc/openvpn -it kylemanna/openvpn easyrsa build-client-full CLIENTNAME nopass
-        docker run --rm -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
+        docker run --net=none --rm -v $PWD:/etc/openvpn -it kylemanna/openvpn easyrsa build-client-full CLIENTNAME nopass
+        docker run --net=none --rm -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
 
 * Start the server with:
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -11,7 +11,7 @@ I'd recommend encrypting the archive with something strong (e.g. gpg or openssl 
 
 ## Backup to Archive
 
-    docker run --volumes-from $OVPN_DATA --rm busybox tar -cvf - -C /etc openvpn | xz > openvpn-backup.tar.xz
+    docker run --volumes-from $OVPN_DATA --net=none --rm busybox tar -cvf - -C /etc openvpn | xz > openvpn-backup.tar.xz
 
 ## Restore to New Container
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -15,7 +15,7 @@ If you have more than a few clients, you will want to generate and update your c
 
 Execute the following to generate the configuration for all clients:
 
-    docker run --rm -it --volumes-from $OVPN_DATA --volume /tmp/openvpn_clients:/etc/openvpn/clients kylemanna/openvpn ovpn_getclient_all
+    docker run --net=none --rm -it --volumes-from $OVPN_DATA --volume /tmp/openvpn_clients:/etc/openvpn/clients kylemanna/openvpn ovpn_getclient_all
 
 After doing so, you will find the following files in each of the `$cn` directories:
 
@@ -30,7 +30,7 @@ After doing so, you will find the following files in each of the `$cn` directori
 
 Revoke `client1`'s certificate and generate the certificate revocation list (CRL):
 
-    docker run --rm -it --volumes-from $OVPN_DATA kylemanna/openvpn easyrsa revoke client1
-    docker run --rm -it --volumes-from $OVPN_DATA kylemanna/openvpn easyrsa gen-crl
+    docker run --net=none --rm -it --volumes-from $OVPN_DATA kylemanna/openvpn easyrsa revoke client1
+    docker run --net=none --rm -it --volumes-from $OVPN_DATA kylemanna/openvpn easyrsa gen-crl
 
 The OpenVPN server will read this change every time a client connects (no need to restart server) and deny clients access using revoked certificates.

--- a/docs/paranoid.md
+++ b/docs/paranoid.md
@@ -5,9 +5,9 @@ As mentioned in the [backup section](/docs/backup.md), there are good reasons to
 
 Execute the following commands. Note that you might want to change the volume `$PWD` or use a data docker container for this.
 
-    docker run --rm -t -i -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
-    docker run --rm -t -i -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_initpki
-    docker run --rm -t -i -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_copy_server_files
+    docker run --net=none --rm -t -i -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
+    docker run --net=none --rm -t -i -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_initpki
+    docker run --net=none --rm -t -i -v $PWD:/etc/openvpn kylemanna/openvpn ovpn_copy_server_files
 
 The [`ovpn_copy_server_files`](/bin/ovpn_copy_server_files) script puts all the needed configuration in a subdirectory which defaults to `$OPENVPN/server`. All you need to do now is to copy this directory to the server and you are good to go.
 
@@ -22,7 +22,7 @@ If you want to select the cyphers used by OpenVPN the following parameters of th
 
 The following options have been tested successfully:
 
-    docker run --volumes-from $OVPN_DATA --rm kylemanna/openvpn ovpn_genconfig -C 'AES-256-CBC' -a 'SHA384'
+    docker run --volumes-from $OVPN_DATA --net=none --rm kylemanna/openvpn ovpn_genconfig -C 'AES-256-CBC' -a 'SHA384'
 
 Changing the `tls-cipher` option seems to be more complicated because some clients (namely NetworkManager in Debian Jessie) seem to have trouble with this. Running `openvpn` manually also did not solve the issue:
 

--- a/docs/static-ips.md
+++ b/docs/static-ips.md
@@ -6,7 +6,7 @@ The docker image is setup for static client configuration on the 192.168.254.0/2
 
 1. Create a client specific configuration:
 
-        $ echo "ifconfig-push 192.168.254.1 192.168.254.2" | docker run --volumes-from $OVPN_DATA -i --rm kylemanna/openvpn tee /etc/openvpn/ccd/CERT_COMMON_NAME
+        echo "ifconfig-push 192.168.254.1 192.168.254.2" | docker run --volumes-from $OVPN_DATA -i --net=none --rm kylemanna/openvpn tee /etc/openvpn/ccd/CERT_COMMON_NAME
         ifconfig-push 192.168.254.1 192.168.254.2
 
 2. Wait for client to reconnect if necessary
@@ -21,4 +21,4 @@ Login to the data volume with a `bash` container, note only changes in /etc/open
 
 If you're running an old configuration and need to upgrade it to pull in the ccd directory run the following:
 
-    docker run  --volumes-from $OVPN_DATA --rm kylemanna/openvpn ovpn_genconfig
+    docker run --volumes-from $OVPN_DATA --net=none --rm kylemanna/openvpn ovpn_genconfig


### PR DESCRIPTION
And there is more paranoid stuff from me :smile: 

This should mitigate a hypothetical compromise of the scripts used to
manage the CA and other sensitive material.

The examples should still work and make sense although I have not tried
all of them with this change applied.

Note that I did not append the --net=none to all examples because in
some cases network is probably wanted.