### PR TITLE
ovpn_copy_server_files: Copy openvpn.conf instead of symlinking locally.

### DIFF
--- a/bin/ovpn_copy_server_files
+++ b/bin/ovpn_copy_server_files
@@ -21,6 +21,8 @@ fi
 rm --recursive --force "$TARGET/pki/private" "$TARGET/pki/issued"
 
 echo "
+openvpn.conf
+ovpn_env.sh
 pki/private/${OVPN_CN}.key
 pki/issued/${OVPN_CN}.crt
 pki/dh.pem
@@ -29,7 +31,6 @@ pki/ca.crt
 " | rsync --recursive --verbose \
     --files-from - \
     "$OPENVPN/" "$TARGET"
-ln --symbolic --force ../openvpn.conf ../ovpn_env.sh "$TARGET"
 mkdir -p "$TARGET/ccd"
 
 echo "Created the openvpn configuration for the server: $TARGET"


### PR DESCRIPTION
Symlinked files can be resolved by rsync when using the configuration on remote
servers but for local testing having the actual file is beneficial.