### PR TITLE
Allow custom client options.

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -23,22 +23,46 @@ fi
 
 cn="$1"
 parm="$2"
+additional_parameters="$3"
+additional_options=()
+
 
 if [ ! -f "$EASYRSA_PKI/private/${cn}.key" ]; then
     echo "Unable to find \"${cn}\", please try again or generate the key first" >&2
     exit 1
 fi
 
+## http://stackoverflow.com/a/8574392
+containsElement () {
+    local e
+    for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+    return 1
+}
+
 get_client_config() {
     mode="$1"
+    additional_parameters="$2"
+
+    if [ -n "$additional_parameters" ]; then
+        IFS=';' read -ra additional_parameters_list <<< "$additional_parameters"
+        for parameter in "${additional_parameters_list[@]}"; do
+            openvpn_option="${parameter%% *}"
+            additional_options+=("$openvpn_option")
+        done
+    fi
+
     echo "
 client
 nobind
 dev $OVPN_DEVICE
 remote-cert-tls server
-
-remote $OVPN_CN $OVPN_PORT $OVPN_PROTO
 "
+
+    if ! containsElement "remote" "${additional_options[@]}"
+    then
+        echo -e "remote $OVPN_CN $OVPN_PORT $OVPN_PROTO\n"
+    fi
+
     if [ "$mode" == "combined" ]; then
         echo "
 <key>
@@ -84,23 +108,30 @@ $OVPN_ADDITIONAL_CLIENT_CONFIG
     if [ -n "$OVPN_AUTH" ]; then
         echo "auth $OVPN_AUTH"
     fi
+
+    if [ -n "$additional_parameters" ]; then
+        IFS=';' read -ra additional_parameters_list <<< "$additional_parameters"
+        for parameter in "${additional_parameters_list[@]}"; do
+            echo "$parameter"
+        done
+    fi
 }
 
 dir="$OPENVPN/clients/$cn"
 case "$parm" in
     "separated")
         mkdir -p "$dir"
-        get_client_config "$parm" > "$dir/${cn}.ovpn"
+        get_client_config "$parm" "$additional_parameters" > "$dir/${cn}.ovpn"
         cp "$EASYRSA_PKI/private/${cn}.key" "$dir/${cn}.key"
         cp "$EASYRSA_PKI/ca.crt" "$dir/ca.crt"
         cp "$EASYRSA_PKI/issued/${cn}.crt" "$dir/${cn}.crt"
         cp "$EASYRSA_PKI/ta.key" "$dir/ta.key"
         ;;
     "" | "combined")
-        get_client_config "combined"
+        get_client_config "combined" "$additional_parameters"
         ;;
     "combined-save")
-        get_client_config "combined" > "$dir/${cn}-combined.ovpn"
+        get_client_config "combined" "$additional_parameters" > "$dir/${cn}-combined.ovpn"
         ;;
     *)
         echo "This script can produce the client configuration in to formats:" >&2

--- a/bin/ovpn_getclient_all
+++ b/bin/ovpn_getclient_all
@@ -18,8 +18,8 @@ for name in issued/*.crt; do
     name=${name%.crt}
     name=${name#issued/}
     if [ "$name" != "$OVPN_CN" ]; then
-        ovpn_getclient "$name" separated
-        ovpn_getclient "$name" combined-save
+        ovpn_getclient "$name" separated "${@}"
+        ovpn_getclient "$name" combined-save "${@}"
     fi
 done
 popd

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -26,6 +26,14 @@ After doing so, you will find the following files in each of the `$cn` directori
     $cn.key
     ta.key
 
+## Custom client configuration options
+
+In case you want to add or change certain client options you can use the third parameter to specify them. This can for example be used in a multi-server setup to write all remotes in the client’s configuration and have them choose which server to connect to. The following command can be used to achieve this:
+
+    docker run --rm -it --volumes-from $OVPN_DATA --volume /tmp/openvpn_clients:/etc/openvpn/clients kylemanna/openvpn ovpn_getclient $cn combined-save "remote vpn.example.com;remote vpn.example.net;remote-random"
+
+Note that by specifying one or more remote parameter manually, the default remote entry is omitted. This was done to allow you to choose a order for the remotes because OpenVPN will try the remotes in the specified order unless the "remote-random" option set.
+
 ## Revoking Client Certificates
 
 Revoke `client1`'s certificate and generate the certificate revocation list (CRL):


### PR DESCRIPTION
In case you want to add or change certain client options you can use the third parameter to specify them. This can for example be used in a multi-server setup to write all remotes in the client’s configuration and have clients choose which server to connect to. The following command can be used to achieve this:

    docker run --rm -it --volumes-from $OVPN_DATA --volume /tmp/openvpn_clients:/etc/openvpn/clients kylemanna/openvpn ovpn_getclient $cn combined-save "remote vpn.example.com;remote vpn.example.net;remote-random"

Note that by specifying one or more remote parameter manually, the default remote entry is omitted. This was done to allow you to choose a order for the remotes because OpenVPN will try the remotes in the specified order unless the "remote-random" option set.