### PR TITLE
Switch to Alpine for Base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,18 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
-# Leaner build then Ubunutu
+# Leaner build then Ubuntu
 FROM alpine:3.2
 
 MAINTAINER Kyle Manna <kyle@kylemanna.com>
 
-RUN apk update && \
-    apk add openvpn iptables curl bash && \
+RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
+    apk add --update openvpn iptables bash easy-rsa && \
+    ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
-
-RUN mkdir -p /usr/local/share/easy-rsa && cd /usr/local/share/easy-rsa && \
-    curl -L https://github.com/OpenVPN/easy-rsa/archive/v3.0.0.tar.gz | tar xzf - easy-rsa-3.0.0/easyrsa3 && \
-    mv easy-rsa-3.0.0/easyrsa3 . && rmdir easy-rsa-3.0.0 && \
-    ln -s /usr/local/share/easy-rsa/easyrsa3/easyrsa /usr/local/bin
 
 # Needed by scripts
 ENV OPENVPN /etc/openvpn
-ENV EASYRSA /usr/local/share/easy-rsa/easyrsa3
+ENV EASYRSA /usr/share/easy-rsa
 ENV EASYRSA_PKI $OPENVPN/pki
 ENV EASYRSA_VARS_FILE $OPENVPN/vars
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
 # Leaner build then Ubunutu
-FROM debian:jessie
+FROM alpine:3.2
 
 MAINTAINER Kyle Manna <kyle@kylemanna.com>
 
-RUN apt-get update && \
-    apt-get install -y openvpn iptables curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apk update && \
+    apk add openvpn iptables curl bash && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
-RUN mkdir -p /usr/local/share/easy-rsa && \
-    curl -L https://github.com/OpenVPN/easy-rsa/archive/v3.0.0.tar.gz | tar xzf - --strip=1 -C /usr/local/share/easy-rsa easy-rsa-3.0.0/easyrsa3 && \
+RUN mkdir -p /usr/local/share/easy-rsa && cd /usr/local/share/easy-rsa && \
+    curl -L https://github.com/OpenVPN/easy-rsa/archive/v3.0.0.tar.gz | tar xzf - easy-rsa-3.0.0/easyrsa3 && \
+    mv easy-rsa-3.0.0/easyrsa3 . && rmdir easy-rsa-3.0.0 && \
     ln -s /usr/local/share/easy-rsa/easyrsa3/easyrsa /usr/local/bin
 
 # Needed by scripts


### PR DESCRIPTION
Stumbled on Alpine the other day and it significantly reduces the size of the Docker image. (150 -> 12MB).

I'm running it on three of my existing personal VPNs without issue.  To use it with systemd it's as simple as installing the [systemd service file](https://github.com/kylemanna/docker-openvpn/blob/master/init/docker-openvpn%40.service) and then overriding the image with something like.

    # /etc/systemd/system/docker-openvpn@vpn0.service.d/local.conf
    Environment="IMG=kylemanna/openvpn:alpine"

Run `systemd daemon-reload` and then restart the service.

Random [babbling on my blog](http://bit.ly/1XHb5nB)

Thanks to @tsing I was able to pull in the EasyRSA package which should include package signature verification at @ypid's request.