### PR TITLE
Respect the -D flag

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -211,7 +211,8 @@ EOF
 [ -n "$OVPN_AUTH" ] && echo "auth $OVPN_AUTH" >> "$conf"
 
 [ -n "$OVPN_CLIENT_TO_CLIENT" ] && echo "client-to-client" >> "$conf"
-for i in "${OVPN_DNS_SERVERS[@]}"; do
+
+[ "$OVPN_DNS" == "1" ] && for i in "${OVPN_DNS_SERVERS[@]}"; do
   echo "push dhcp-option DNS $i" >> "$conf"
 done
 # Append Routes


### PR DESCRIPTION
It looks like edfbffb85f4684b87a906c6c1f1aeba6aaf870aa caused the
OVPN_DNS variable to start being ignored, meaning the -D flag was a
no-op.