### PR TITLE
Use OVPN_ADDITIONAL_CLIENT_CONFIG in all ovpn_getclient modes

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -88,7 +88,9 @@ tls-auth ta.key 1
         echo "comp-lzo"
     fi
 
-    echo -e $OVPN_ADDITIONAL_CLIENT_CONFIG
+    if [ -n "$OVPN_ADDITIONAL_CLIENT_CONFIG" ]; then
+        echo -e $OVPN_ADDITIONAL_CLIENT_CONFIG
+    fi
 }
 
 dir="$OPENVPN/clients/$cn"

--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -61,7 +61,6 @@ key ${cn}.key
 ca ca.crt
 cert ${cn}.crt
 tls-auth ta.key 1
-$OVPN_ADDITIONAL_CLIENT_CONFIG
 "
     fi
 
@@ -88,6 +87,8 @@ $OVPN_ADDITIONAL_CLIENT_CONFIG
     if [ -n "$OVPN_COMP_LZO" ]; then
         echo "comp-lzo"
     fi
+
+    echo -e $OVPN_ADDITIONAL_CLIENT_CONFIG
 }
 
 dir="$OPENVPN/clients/$cn"


### PR DESCRIPTION
`OVPN_ADDITIONAL_CLIENT_CONFIG` environment variable is used only in "separated" mode in `ovpn_getclient` script now. These changes make it usable in all modes.