### PR TITLE
Add openvpn.conf gerneration -f fragment directive option

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -51,6 +51,7 @@ usage() {
     echo " -a    Authenticate  packets with HMAC using the given message digest algorithm (auth)."
     echo " -z    Enable comp-lzo compression."
     echo " -2    Enable two factor authentication using Google Authenticator."
+    echo " -f    Set the fragment directive."
 }
 
 if [ "$DEBUG" == "1" ]; then
@@ -80,7 +81,7 @@ OVPN_AUTH=''
 [ -r "$OVPN_ENV" ] && source "$OVPN_ENV"
 
 # Parse arguments
-while getopts ":a:C:T:r:s:du:cp:n:DNm:tz2" opt; do
+while getopts ":a:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
     case $opt in
         a)
             OVPN_AUTH="$OPTARG"
@@ -130,6 +131,9 @@ while getopts ":a:C:T:r:s:du:cp:n:DNm:tz2" opt; do
         2)
             OVPN_OTP_AUTH=1
             ;;
+        f)
+            OVPN_FRAGMENT=$OPTARG
+            ;;
         \?)
             set +x
             echo "Invalid option: -$OPTARG" >&2
@@ -177,6 +181,7 @@ export OVPN_CLIENT_TO_CLIENT OVPN_PUSH OVPN_NAT OVPN_DNS OVPN_MTU OVPN_DEVICE
 export OVPN_TLS_CIPHER OVPN_CIPHER OVPN_AUTH
 export OVPN_COMP_LZO
 export OVPN_OTP_AUTH
+export OVPN_FRAGMENT
 
 # Preserve config
 if [ -f "$OVPN_ENV" ]; then
@@ -222,6 +227,8 @@ EOF
 
 [ -n "$OVPN_CLIENT_TO_CLIENT" ] && echo "client-to-client" >> "$conf"
 [ -n "$OVPN_COMP_LZO" ] && echo "comp-lzo" >> "$conf"
+
+[ -n "$OVPN_FRAGMENT" ] && echo "fragment $OVPN_FRAGMENT" >> "$conf"
 
 [ "$OVPN_DNS" == "1" ] && for i in "${OVPN_DNS_SERVERS[@]}"; do
   echo "push dhcp-option DNS $i" >> "$conf"

--- a/tests/openvpn_conf_options.test.sh
+++ b/tests/openvpn_conf_options.test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+OVPN_DATA=opvn-data
+
+IMG=kylemanna/openvpn
+IMG=rudijs/docker-openvpne:1.0.0
+
+# Function to fail
+abort() { cat <<< "$@" 1>&2; exit 1; }
+
+#
+# Create a docker container with the config data
+#
+sudo docker run --name $OVPN_DATA -v /etc/openvpn busybox
+
+#
+# Generate openvpn.config file
+#
+SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::' | head -n1)
+sudo docker run --volumes-from $OVPN_DATA --rm $IMG ovpn_genconfig -u udp://$SERV_IP -f 1400
+
+#
+# grep for config lines from openvpn.conf
+# add more tests for more configs as required
+#
+
+# 1. verb config
+CONFIG_REQUIRED_VERB="verb 3"
+CONFIG_MATCH_VERB=$(sudo docker run --rm -it --volumes-from $OVPN_DATA busybox grep verb /etc/openvpn/openvpn.conf)
+
+# 2. fragment config
+CONFIG_REQUIRED_FRAGMENT="fragment 1400"
+CONFIG_MATCH_FRAGMENT=$(sudo docker run --rm -it --volumes-from $OVPN_DATA busybox grep fragment /etc/openvpn/openvpn.conf)
+
+#
+# Clean up
+#
+# sudo docker rm -f $OVPN_DATA
+
+#
+# Tests
+#
+
+if [[ $CONFIG_MATCH_VERB =~ $CONFIG_REQUIRED_VERB ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_VERB == $CONFIG_MATCH_VERB"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_VERB != $CONFIG_MATCH_VERB"
+fi
+
+if [[ $CONFIG_MATCH_FRAGMENT =~ $CONFIG_REQUIRED_FRAGMENT ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_FRAGMENT == $CONFIG_MATCH_FRAGMENT"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_FRAGMENT != $CONFIG_MATCH_FRAGMENT"
+fi

--- a/tests/openvpn_conf_options.test.sh
+++ b/tests/openvpn_conf_options.test.sh
@@ -3,7 +3,6 @@
 OVPN_DATA=opvn-data
 
 IMG=kylemanna/openvpn
-IMG=rudijs/docker-openvpne:1.0.0
 
 # Function to fail
 abort() { cat <<< "$@" 1>&2; exit 1; }


### PR DESCRIPTION
Hi Kyle,

I've gone ahead and added the "-f" option for adding the "fragment" directive to openvpn.conf.

I may or may not have gone about it the best way so please feel free to edit/update where appropriate.

There's a new test file which greps the openvpn.conf file for config lines.

I didn't see any existing openvpn.conf testing (maybe I over looked it?) so I added a new test file.

As it is now it only checks for two config's "verb" and "fragment".

I used "verb" while developing, then added "fragment" after, with some minor refactoring more could be added.

When I run the test on my local build, it looks like:

```
./tests/openvpn_conf_options.test.sh                                                                                    ⏎ ✱ ◼
Successfully generated config
opvn-data
==> Config match found: verb 3 == verb 3
==> Config match found: fragment 1400 == fragment 1400
```

Here's a sample of the openvpn.conf file that is generated - note the "fragment" directive:

```
server 192.168.255.0 255.255.255.0
verb 3
key /etc/openvpn/pki/private/192.168.0.101.key
ca /etc/openvpn/pki/ca.crt
cert /etc/openvpn/pki/issued/192.168.0.101.crt
dh /etc/openvpn/pki/dh.pem
tls-auth /etc/openvpn/pki/ta.key
key-direction 0
keepalive 10 60
persist-key
persist-tun

proto udp
# Rely on Docker to do port mapping, internally always 1194
port 1194
dev tun0
status /tmp/openvpn-status.log

user nobody
group nogroup
fragment 1400
push dhcp-option DNS 8.8.8.8
push dhcp-option DNS 8.8.4.4
route 192.168.254.0 255.255.255.0
```

Please let me know if this is all good when you have a moment.

Thanks!
