### PR TITLE
Automatically creating CCD directory

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -154,6 +154,9 @@ while getopts ":a:e:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
     esac
 done
 
+# Create ccd directory for static routes
+[ ! -d "$OPENVPN/ccd" ] && mkdir -p $OPENVPN/ccd
+
 # if new routes were not defined with -r, use default
 [ ${#TMP_ROUTES[@]} -gt 0 ] && OVPN_ROUTES=("${TMP_ROUTES[@]}")
 

--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -24,7 +24,7 @@ easyrsa init-pki
 easyrsa build-ca $nopass
 
 easyrsa gen-dh
-openvpn --genkey --secret $OPENVPN/pki/ta.key
+openvpn --genkey --secret $EASYRSA_PKI/ta.key
 
 # Was nice to autoset, but probably a bad idea in practice, users should
 # have to explicitly specify the common name of their server


### PR DESCRIPTION
This arranges to automatically create the ccd sub-directory as part of the configuration generation phase. Without this directory, the steps documented for static addresses allocation will not work out of the box.

The current implementation automatically adds `--client-config-dir` as a startup option to OpenVPN as part of `ovpn-run`, maybe should this be moved into the generated configuration instead?