### PR TITLE
Add "key-direction 1" to client .ovpn

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -35,6 +35,7 @@ get_client_config() {
 client
 nobind
 dev $OVPN_DEVICE
+key-direction 1
 remote-cert-tls server
 
 remote $OVPN_CN $OVPN_PORT $OVPN_PROTO


### PR DESCRIPTION
Adding this setting avoids connection errors on some clients, when the .ovpn file is imported directly in Gnome NetworkManager 1.2.0.

Server logs:
    Authenticate/Decrypt packet error: packet HMAC authentication failed
    TLS Error: incoming packet authentication failed from ...

Client logs:
    nm-openvpn: TLS Error: TLS key negotiation failed to occur within 60 seconds (check your network connectivity)
    nm-openvpn: TLS Error: TLS handshake failed

NetworkManager version: 1.2.0
openvpn version: OpenVPN 2.3.10
Ubuntu 16.04