### PR TITLE
Derive from alpine 3.4 instead of 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
 # Smallest base image
-FROM alpine:3.2
+FROM alpine:3.4
 
 MAINTAINER Kyle Manna <kyle@kylemanna.com>
 


### PR DESCRIPTION
To work around known vulnerabilities in alpine 3.2 such as CVE-2016-2177
and CVE-2016-2178.

Fix #140

My local ad-hoc test worked, so assuming CI also passes this should be good to go.