### PR TITLE
Fix for Windows 10 DNS Leak

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -218,6 +218,7 @@ key-direction 0
 keepalive 10 60
 persist-key
 persist-tun
+push block-outside-dns
 
 proto $OVPN_PROTO
 # Rely on Docker to do port mapping, internally always 1194


### PR DESCRIPTION
The patch includes an update to the OpenVPN server config to
address a DNS leak when using Windows 10, as documented at:
https://community.openvpn.net/openvpn/ticket/605