### PR TITLE
Update README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -4,8 +4,9 @@ Philosophy is to not re-invent the wheel while allowing users to quickly test re
 
 Example invocation from top-level of repository:
 
-    docker build -t openvpn .
-    tests/run.sh openvpn
+    docker build -t kylemanna/openvpn .
+    test/run.sh kylemanna/openvpn
+    # Be sure to pull kylemanna/openvpn:latest after you're done testing
 
 More details: https://github.com/docker-library/official-images/tree/master/test
 


### PR DESCRIPTION
The tests have the image name hardcoded to kylemanna/openvpn.  Attempting to run with any other name causes the tests to run against the latest image from docker hub.