### PR TITLE
Update documentation for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ a corresponding [Digital Ocean Community Tutorial](http://bit.ly/1AGUZkq).
 
         docker run -v $OVPN_DATA:/etc/openvpn --rm kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
 
+## `docker-compose`
+
+If you prefer to use `docker-compose` please refer to the [documentation](docs/docker-compose.md).
+
 ## Debugging Tips
 
 * Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
 
         docker run -v $OVPN_DATA:/etc/openvpn -p 1194:1194/udp --privileged -e DEBUG=1 kylemanna/openvpn
 
-* Test using a client that has openvpn installed correctly 
+* Test using a client that has openvpn installed correctly
 
         $ openvpn --config CLIENTNAME.ovpn
 

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -2,41 +2,67 @@
 
 * Add a new service in docker-compose.yml
 
-        version: '2'
-        services:
-          openvpn:
-            cap_add:
-             - NET_ADMIN
-            image: kylemanna/openvpn
-            ports:
-             - "1194:1194/udp"
-            restart: always
-            volumes:
-             - ./openvpn/conf:/etc/openvpn
+```yaml
+version: '2'
+services:
+  openvpn:
+    cap_add:
+     - NET_ADMIN
+    image: kylemanna/openvpn
+    container_name: openvpn
+    ports:
+     - "1194:1194/udp"
+    restart: always
+    volumes:
+     - ./openvpn-data/conf:/etc/openvpn
+```
+
 
 * Initialize the configuration files and certificates
 
-        docker-compose run --rm openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
-        docker-compose run --rm openvpn ovpn_initpki
-        
+```bash
+docker-compose run --rm openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
+docker-compose run --rm openvpn ovpn_initpki
+```
+
 * Fix ownership (depending on how to handle your backups, this may not be needed)
 
-        sudo chown -R $(whoami): ./openvpn
+```bash
+sudo chown -R $(whoami): ./openvpn-data
+```
 
 * Start OpenVPN server process
 
-        docker-compose up -d openvpn
+```bash
+docker-compose up -d openvpn
+```
 
-* Generate a client certificate without a passphrase
+* You can access the container logs with
 
-        docker-compose run --rm openvpn easyrsa build-client-full CLIENTNAME nopass
+```bash
+docker-compose logs -f
+```
+
+* Generate a client certificate
+
+```bash
+export CLIENTNAME="your_client_name"
+# with a passphrase (recommended)
+docker-compose exec openvpn easyrsa build-client-full $CLIENTNAME
+# without a passphrase (not recommended)
+docker-compose exec openvpn easyrsa build-client-full $CLIENTNAME nopass
+```
 
 * Retrieve the client configuration with embedded certificates
 
-        docker-compose run --rm openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
+```bash
+docker-compose exec openvpn ovpn_getclient $CLIENTNAME > $CLIENTNAME.ovpn
+```
 
 ## Debugging Tips
 
 * Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
 
-        docker-compose run -e DEBUG=1 openvpn
+```bash
+docker-compose run -e DEBUG=1 openvpn
+```


### PR DESCRIPTION
Add a note on README.md about docker-compose and update the doc to use `docker exec` instead of `docker run` when possible.

Also don't you think the init commands (`ovpn_genconfig` and `ovpn_initpki`) could be automatically launched at start when no config is detected ? VPN.SERVERNAME.COM and password could be set with the `-e` option of `docker-compose run`.