### PR TITLE
Add -E flag for adding extra client config

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -7,6 +7,7 @@
 TMP_PUSH_CONFIGFILE=$(mktemp -t vpn_push.XXXXXXX)
 TMP_ROUTE_CONFIGFILE=$(mktemp -t vpn_route.XXXXXXX)
 TMP_EXTRA_CONFIGFILE=$(mktemp -t vpn_extra.XXXXXXX)
+TMP_EXTRA_CLIENT_CONFIGFILE=$(mktemp -t vpn_extra_client.XXXXXXX)
 
 #Traceback on Error and Exit come from https://docwhat.org/tracebacks-in-bash/
 set -eu
@@ -45,6 +46,7 @@ on_exit() {
   rm -f $TMP_PUSH_CONFIGFILE
   rm -f $TMP_ROUTE_CONFIGFILE
   rm -f $TMP_EXTRA_CONFIGFILE
+  rm -f $TMP_EXTRA_CLIENT_CONFIGFILE
   local _ec="$?"
   if [[ $_ec != 0 && "${_showed_traceback}" != t ]]; then
     traceback 1
@@ -83,6 +85,7 @@ usage() {
     echo "usage: $0 [-d]"
     echo "                  -u SERVER_PUBLIC_URL"
     echo "                 [-e EXTRA_SERVER_CONFIG ]"
+    echo "                 [-E EXTRA_CLIENT_CONFIG ]"
     echo "                 [-f FRAGMENT ]"
     echo "                 [-n DNS_SERVER ...]"
     echo "                 [-p PUSH ...]"
@@ -127,6 +130,13 @@ process_extra_config() {
 
 }
 
+process_extra_client_config() {
+  local ovpn_extra_config=''
+  ovpn_extra_config="$1"
+  echo "Processing Extra Client Config: '${ovpn_extra_config}'"
+  [[ -n "$ovpn_extra_config" ]] && echo "$ovpn_extra_config" >> "$TMP_EXTRA_CLIENT_CONFIGFILE"
+}
+
 if [ "${DEBUG:-}" == "1" ]; then
   set -x
 fi
@@ -159,13 +169,16 @@ CUSTOM_ROUTE_CONFIG=''
 [ -r "$OVPN_ENV" ] && source "$OVPN_ENV"
 
 # Parse arguments
-while getopts ":a:e:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
+while getopts ":a:e:E:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
     case $opt in
         a)
             OVPN_AUTH="$OPTARG"
             ;;
         e)
             process_extra_config "$OPTARG"
+            ;;
+        E)
+            process_extra_client_config "$OPTARG"
             ;;
         C)
             OVPN_CIPHER="$OPTARG"
@@ -254,6 +267,9 @@ fi
 [ -z "$OVPN_PORT" ] && OVPN_PORT=1194
 [ -z "$CUSTOM_ROUTE_CONFIG" ] && process_route_config "192.168.254.0/24"
 
+# Save extra client config
+OVPN_ADDITIONAL_CLIENT_CONFIG=$(cat $TMP_EXTRA_CLIENT_CONFIGFILE)
+
 export OVPN_SERVER OVPN_ROUTES OVPN_DEFROUTE
 export OVPN_SERVER_URL OVPN_ENV OVPN_PROTO OVPN_CN OVPN_PORT
 export OVPN_CLIENT_TO_CLIENT OVPN_PUSH OVPN_NAT OVPN_DNS OVPN_MTU OVPN_DEVICE
@@ -261,6 +277,7 @@ export OVPN_TLS_CIPHER OVPN_CIPHER OVPN_AUTH
 export OVPN_COMP_LZO
 export OVPN_OTP_AUTH
 export OVPN_FRAGMENT
+export OVPN_ADDITIONAL_CLIENT_CONFIG
 
 # Preserve config
 if [ -f "$OVPN_ENV" ]; then
@@ -268,7 +285,18 @@ if [ -f "$OVPN_ENV" ]; then
     echo "Backing up $OVPN_ENV -> $bak_env"
     mv "$OVPN_ENV" "$bak_env"
 fi
-export | grep OVPN_ > "$OVPN_ENV"
+
+# Like `export | grep OVPN_ > "$OVPN_ENV"` but handles multiline variables
+set +u
+while read var ; do
+  eval value=\$$var
+  if [ -n "$value" ]; then
+    echo "declare -x $var=\"$value\"" >> "$OVPN_ENV"
+  else
+    echo "declare -x $var" >> "$OVPN_ENV"
+  fi
+done < <(export | egrep -o '(OVPN_[^=]+)')
+set -u
 
 conf=${OPENVPN:-}/openvpn.conf
 if [ -f "$conf" ]; then

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -267,8 +267,10 @@ fi
 [ -z "$OVPN_PORT" ] && OVPN_PORT=1194
 [ -z "$CUSTOM_ROUTE_CONFIG" ] && process_route_config "192.168.254.0/24"
 
-# Save extra client config
-OVPN_ADDITIONAL_CLIENT_CONFIG=$(cat $TMP_EXTRA_CLIENT_CONFIGFILE)
+# Save extra client config from temp file only if temp file is not empty
+if [ -s "$TMP_EXTRA_CLIENT_CONFIGFILE" ]; then
+  OVPN_ADDITIONAL_CLIENT_CONFIG=$(cat $TMP_EXTRA_CLIENT_CONFIGFILE)
+fi
 
 export OVPN_SERVER OVPN_ROUTES OVPN_DEFROUTE
 export OVPN_SERVER_URL OVPN_ENV OVPN_PROTO OVPN_CN OVPN_PORT

--- a/test/tests/conf_options/container.sh
+++ b/test/tests/conf_options/container.sh
@@ -163,3 +163,32 @@ then
 else
   abort "==> Config match not found: $CONFIG_REQUIRED_ROUTE_2 != $CONFIG_MATCH_ROUTE_2"
 fi
+
+# Test generated client config
+
+# gen udp client with tcp fallback
+ovpn_genconfig -u udp://$SERV_IP -E "remote $SERV_IP 443 tcp" -E "remote vpn.example.com 443 tcp"
+# nopass is insecure
+EASYRSA_BATCH=1 EASYRSA_REQ_CN="Travis-CI Test CA" ovpn_initpki nopass
+easyrsa build-client-full client-fallback nopass
+ovpn_getclient client-fallback | tee /etc/openvpn/config-fallback.ovpn
+
+CONFIG_REQUIRED_TCP_REMOTE="^remote $SERV_IP 443 tcp"
+CONFIG_MATCH_TCP_REMOTE=$(busybox grep "remote $SERV_IP 443 tcp" /etc/openvpn/config-fallback.ovpn)
+
+CONFIG_REQUIRED_TCP_REMOTE_2="^remote vpn.example.com 443 tcp"
+CONFIG_MATCH_TCP_REMOTE_2=$(busybox grep "remote vpn.example.com 443 tcp" /etc/openvpn/config-fallback.ovpn)
+
+if [[ $CONFIG_MATCH_TCP_REMOTE =~ $CONFIG_REQUIRED_TCP_REMOTE ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_TCP_REMOTE == $CONFIG_MATCH_TCP_REMOTE"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_TCP_REMOTE != $CONFIG_MATCH_TCP_REMOTE"
+fi
+
+if [[ $CONFIG_MATCH_TCP_REMOTE_2 =~ $CONFIG_REQUIRED_TCP_REMOTE_2 ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_TCP_REMOTE_2 == $CONFIG_MATCH_TCP_REMOTE_2"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_TCP_REMOTE_2 != $CONFIG_MATCH_TCP_REMOTE_2"
+fi


### PR DESCRIPTION
This is another approach to the problem I was trying to solve in #193.  The client config already has the `OVPN_ADDITIONAL_CLIENT_CONFIG` variable so I wanted to add a frontend for setting it via `ovpn_genconfig`.

I quickly found out that `export | grep OVPN_ > "$OVPN_ENV"` does not handle multiline variables so I rewrote that section to generate output that matches `export` but grabs the variable names (via egrep) and uses indirect references to grab the values.

This should allow us to cleanly support existing configurations out there who have multiline values for `OVPN_ADDITIONAL_CLIENT_CONFIG` along with allowing a user to pass the `-E` option as many times as they want.