### PR TITLE
Only block external dns when default route is pushed

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -330,8 +330,8 @@ user nobody
 group nogroup
 EOF
 
-#This was in the heredoc, we use the new function instead
-process_push_config "block-outside-dns"
+# only block outside dns when we take the default route
+[ "$OVPN_DEFROUTE" == "1" ] && process_push_config "block-outside-dns"
 
 [ -n "$OVPN_TLS_CIPHER" ] && echo "tls-cipher $OVPN_TLS_CIPHER" >> "$conf"
 [ -n "$OVPN_CIPHER" ] && echo "cipher $OVPN_CIPHER" >> "$conf"

--- a/test/tests/conf_options/container.sh
+++ b/test/tests/conf_options/container.sh
@@ -56,8 +56,8 @@ CONFIG_REQUIRED_DEFAULT_ROUTE="^route 192.168.254.0 255.255.255.0"
 CONFIG_MATCH_DEFAULT_ROUTE=$(busybox grep 'route 192.168.254.0 255.255.255.0' /etc/openvpn/openvpn.conf)
 
 # 9. Should see a push of 'block-outside-dns' by default
-CONFIG_REQUIRED_DEFAULT_ROUTE="^push block-outside-dns"
-CONFIG_MATCH_DEFAULT_ROUTE=$(busybox grep 'push block-outside-dns' /etc/openvpn/openvpn.conf)
+CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS="^push block-outside-dns"
+CONFIG_MATCH_BLOCK_OUTSIDE_DNS=$(busybox grep 'push block-outside-dns' /etc/openvpn/openvpn.conf)
 
 # 10. Should see a push of 'dhcp-option DNS' by default
 CONFIG_REQUIRED_DEFAULT_DNS_1="^push dhcp-option DNS 8.8.8.8"
@@ -125,6 +125,13 @@ then
   echo "==> Config match found: $CONFIG_REQUIRED_DEFAULT_ROUTE == $CONFIG_MATCH_DEFAULT_ROUTE"
 else
   abort "==> Config match not found: $CONFIG_REQUIRED_DEFAULT_ROUTE != $CONFIG_MATCH_DEFAULT_ROUTE"
+fi
+
+if [[ $CONFIG_MATCH_BLOCK_OUTSIDE_DNS =~ $CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS == $CONFIG_MATCH_BLOCK_OUTSIDE_DNS"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS != $CONFIG_MATCH_BLOCK_OUTSIDE_DNS"
 fi
 
 if [[ $CONFIG_MATCH_DEFAULT_DNS_1 =~ $CONFIG_REQUIRED_DEFAULT_DNS_1 ]]

--- a/test/tests/conf_options/container.sh
+++ b/test/tests/conf_options/container.sh
@@ -199,3 +199,32 @@ then
 else
   abort "==> Config match not found: $CONFIG_REQUIRED_TCP_REMOTE_2 != $CONFIG_MATCH_TCP_REMOTE_2"
 fi
+
+# Test non-defroute config
+
+SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::' | head -n1)
+ovpn_genconfig -d -u udp://$SERV_IP -r "172.33.33.0/24" -r "172.34.34.0/24"
+# nopass is insecure
+EASYRSA_BATCH=1 EASYRSA_REQ_CN="Travis-CI Test CA" ovpn_initpki nopass
+easyrsa build-client-full client-fallback nopass
+ovpn_getclient client-fallback | tee /etc/openvpn/config-fallback.ovpn
+
+CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS=""
+CONFIG_MATCH_BLOCK_OUTSIDE_DNS=$(busybox grep 'push block-outside-dns' /etc/openvpn/openvpn.conf)
+
+if [[ $CONFIG_MATCH_BLOCK_OUTSIDE_DNS =~ $CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS == $CONFIG_MATCH_BLOCK_OUTSIDE_DNS"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS != $CONFIG_MATCH_BLOCK_OUTSIDE_DNS"
+fi
+
+CONFIG_REQUIRED_REDIRECT_GATEWAY=""
+CONFIG_MATCH_REDIRECT_GATEWAY=$(busybox grep "redirect-gateway def1" /etc/openvpn/config-fallback.ovpn)
+
+if [[ $CONFIG_MATCH_REDIRECT_GATEWAY =~ $CONFIG_REQUIRED_REDIRECT_GATEWAY ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_REDIRECT_GATEWAY == $CONFIG_MATCH_REDIRECT_GATEWAY"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_REDIRECT_GATEWAY != $CONFIG_MATCH_REDIRECT_GATEWAY"
+fi


### PR DESCRIPTION
When we create VPNs, we use the `-d` flag to prevent grabbing the default route and then add `-p` flags to push specific routes.  This has worked well, but when we created a VPN last week, we noticed that when we connected from a Windows computer, we were unable to resolve DNS queries.  We fixed the issue by removing `push block-outside-dns` from the VPN configuration.

It appears that `push block-outside-dns` was [added](https://github.com/kylemanna/docker-openvpn/commit/bcedc8d6d6b5a69e94ccfafb084792762d454602) to support the "road warrior" use case, where the VPN grabs all traffic.

This change updates `ovpn_genconfig` to only insert `push block-outside-dns` when the default route is grabbed.