### PR TITLE
Add an option for setting different values for keepalive

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -95,10 +95,12 @@ usage() {
     echo "optional arguments:"
     echo " -2    Enable two factor authentication using Google Authenticator."
     echo " -a    Authenticate  packets with HMAC using the given message digest algorithm (auth)."
+    echo " -b    Disable 'push block-outside-dns'"
     echo " -c    Enable client-to-client option"
     echo " -C    A list of allowable TLS ciphers delimited by a colon (cipher)."
-    echo " -d    Disable NAT routing and default route"
+    echo " -d    Disable default route"
     echo " -D    Do not push dns servers"
+    echo " -k    Set keepalive. Default: '10 60'"
     echo " -m    Set client MTU"
     echo " -N    Configure NAT to access external server network"
     echo " -t    Use TAP device (instead of TUN device)"
@@ -157,6 +159,7 @@ OVPN_NAT=0
 OVPN_DNS=1
 OVPN_DEVICE="tun"
 OVPN_DEVICEN=0
+OVPN_KEEPALIVE="10 60"
 OVPN_DNS_SERVERS=("8.8.8.8" "8.8.4.4")
 TMP_DNS_SERVERS=()
 OVPN_TLS_CIPHER=''
@@ -164,12 +167,14 @@ OVPN_CIPHER=''
 OVPN_AUTH=''
 OVPN_EXTRA_CONFIG=''
 CUSTOM_ROUTE_CONFIG=''
+OVPN_COMP_LZO=0
+OVPN_DISABLE_PUSH_BLOCK_DNS=0
 
 # Import defaults if present
 [ -r "$OVPN_ENV" ] && source "$OVPN_ENV"
 
 # Parse arguments
-while getopts ":a:e:E:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
+while getopts ":a:e:E:C:T:r:s:du:bcp:n:k:DNmf:tz2" opt; do
     case $opt in
         a)
             OVPN_AUTH="$OPTARG"
@@ -195,9 +200,13 @@ while getopts ":a:e:E:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
             ;;
         d)
             OVPN_DEFROUTE=0
+            OVPN_DISABLE_PUSH_BLOCK_DNS=1
             ;;
         u)
             OVPN_SERVER_URL=$OPTARG
+            ;;
+        b)
+            OVPN_DISABLE_PUSH_BLOCK_DNS=1
             ;;
         c)
             OVPN_CLIENT_TO_CLIENT=1
@@ -213,6 +222,9 @@ while getopts ":a:e:E:C:T:r:s:du:cp:n:DNmf:tz2" opt; do
             ;;
         N)
             OVPN_NAT=1
+            ;;
+        k)
+            OVPN_KEEPALIVE="$OPTARG"
             ;;
         m)
             OVPN_MTU=$OPTARG
@@ -265,7 +277,7 @@ fi
 # Apply defaults
 [ -z "$OVPN_PROTO" ] && OVPN_PROTO=udp
 [ -z "$OVPN_PORT" ] && OVPN_PORT=1194
-[ -z "$CUSTOM_ROUTE_CONFIG" ] && process_route_config "192.168.254.0/24"
+[ -z "$CUSTOM_ROUTE_CONFIG" ] && [ "$OVPN_DEFROUTE" == "1" ] && process_route_config "192.168.254.0/24"
 
 # Save extra client config from temp file only if temp file is not empty
 if [ -s "$TMP_EXTRA_CLIENT_CONFIGFILE" ]; then
@@ -277,6 +289,7 @@ export OVPN_SERVER_URL OVPN_ENV OVPN_PROTO OVPN_CN OVPN_PORT
 export OVPN_CLIENT_TO_CLIENT OVPN_PUSH OVPN_NAT OVPN_DNS OVPN_MTU OVPN_DEVICE
 export OVPN_TLS_CIPHER OVPN_CIPHER OVPN_AUTH
 export OVPN_COMP_LZO
+export OVPN_DISABLE_PUSH_BLOCK_DNS
 export OVPN_OTP_AUTH
 export OVPN_FRAGMENT
 export OVPN_ADDITIONAL_CLIENT_CONFIG
@@ -316,7 +329,7 @@ cert $EASYRSA_PKI/issued/${OVPN_CN}.crt
 dh $EASYRSA_PKI/dh.pem
 tls-auth $EASYRSA_PKI/ta.key
 key-direction 0
-keepalive 10 60
+keepalive $OVPN_KEEPALIVE
 persist-key
 persist-tun
 
@@ -330,15 +343,18 @@ user nobody
 group nogroup
 EOF
 
-# only block outside dns when we take the default route
-[ "$OVPN_DEFROUTE" == "1" ] && process_push_config "block-outside-dns"
+if [ "${OVPN_DISABLE_PUSH_BLOCK_DNS}" == "1" ]; then
+  echo "Disable default push of 'block-outside-dns'"
+else
+  process_push_config "block-outside-dns"
+fi
 
 [ -n "$OVPN_TLS_CIPHER" ] && echo "tls-cipher $OVPN_TLS_CIPHER" >> "$conf"
 [ -n "$OVPN_CIPHER" ] && echo "cipher $OVPN_CIPHER" >> "$conf"
 [ -n "$OVPN_AUTH" ] && echo "auth $OVPN_AUTH" >> "$conf"
 
 [ -n "${OVPN_CLIENT_TO_CLIENT:-}" ] && echo "client-to-client" >> "$conf"
-[ -n "${OVPN_COMP_LZO:-}" ] && echo "comp-lzo" >> "$conf"
+[ "$OVPN_COMP_LZO" == "1" ] && echo "comp-lzo" >> "$conf"
 
 [ -n "${OVPN_FRAGMENT:-}" ] && echo "fragment $OVPN_FRAGMENT" >> "$conf"
 

--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -97,12 +97,12 @@ tls-auth ta.key 1
         echo "auth-nocache"
     fi
 
-    if [ -n "$OVPN_COMP_LZO" ]; then
+    if [ "$OVPN_COMP_LZO" == "1" ]; then
         echo "comp-lzo"
     fi
 
     if [ -n "$OVPN_OTP_AUTH" ]; then
-	echo reneg-sec 0
+        echo reneg-sec 0
     fi
 }
 
@@ -124,9 +124,9 @@ case "$parm" in
         get_client_config "combined" > "$dir/${cn}-combined.ovpn"
         ;;
     *)
-        echo "This script can produce the client configuration in to formats:" >&2
+        echo "This script can produce the client configuration in two formats:" >&2
         echo "    1. combined (default): All needed configuration and cryptographic material is in one file (Use \"combined-save\" to write the configuration file in the same path as the separated parameter does)." >&2
         echo "    2. separated: Separated files." >&2
-        echo "Please specific one of those options as second parameter." >&2
+        echo "Please specify one of those options as second parameter." >&2
         ;;
 esac

--- a/test/tests/conf_options/container.sh
+++ b/test/tests/conf_options/container.sh
@@ -171,6 +171,17 @@ else
   abort "==> Config match not found: $CONFIG_REQUIRED_ROUTE_2 != $CONFIG_MATCH_ROUTE_2"
 fi
 
+SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::' | head -n1)
+ovpn_genconfig -u udp://$SERV_IP -b
+
+if busybox grep -v 'block-outside-dns' /etc/openvpn/openvpn.conf
+then
+  echo "==> Config '-b' Succesfully remove the 'block-outside-dns' option"
+else
+  abort "==> Config '-b' given, but 'block-outside-dns' option is still present in configuration"
+fi
+
+
 # Test generated client config
 
 # gen udp client with tcp fallback

--- a/test/tests/conf_options/container.sh
+++ b/test/tests/conf_options/container.sh
@@ -13,7 +13,7 @@ max-clients 10
 EOF
 
 SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::' | head -n1)
-ovpn_genconfig -u udp://$SERV_IP -f 1400 -e "$MULTILINE_EXTRA_SERVER_CONF" -e 'duplicate-cn' -e 'topology subnet' -p 'route 172.22.22.0 255.255.255.0'
+ovpn_genconfig -u udp://$SERV_IP -f 1400 -k '60 300' -e "$MULTILINE_EXTRA_SERVER_CONF" -e 'duplicate-cn' -e 'topology subnet' -p 'route 172.22.22.0 255.255.255.0'
 
 #
 # grep for config lines from openvpn.conf
@@ -64,6 +64,11 @@ CONFIG_REQUIRED_DEFAULT_DNS_1="^push dhcp-option DNS 8.8.8.8"
 CONFIG_MATCH_DEFAULT_DNS_1=$(busybox grep 'push dhcp-option DNS 8.8.8.8' /etc/openvpn/openvpn.conf)
 CONFIG_REQUIRED_DEFAULT_DNS_2="^push dhcp-option DNS 8.8.4.4"
 CONFIG_MATCH_DEFAULT_DNS_2=$(busybox grep 'push dhcp-option DNS 8.8.4.4' /etc/openvpn/openvpn.conf)
+
+## Test for keepalive
+# 11. keepalive config
+CONFIG_REQUIRED_KEEPALIVE="^keepalive 60 300"
+CONFIG_MATCH_KEEPALIVE=$(busybox grep keepalive /etc/openvpn/openvpn.conf)
 
 
 #
@@ -146,6 +151,13 @@ then
   echo "==> Config match found: $CONFIG_REQUIRED_DEFAULT_DNS_2 == $CONFIG_MATCH_DEFAULT_DNS_2"
 else
   abort "==> Config match not found: $CONFIG_REQUIRED_DEFAULT_DNS_2 != $CONFIG_MATCH_DEFAULT_DNS_2"
+fi
+
+if [[ $CONFIG_MATCH_KEEPALIVE =~ $CONFIG_REQUIRED_KEEPALIVE ]]
+then
+  echo "==> Config match found: $CONFIG_REQUIRED_KEEPALIVE == $CONFIG_MATCH_KEEPALIVE"
+else
+  abort "==> Config match not found: $CONFIG_REQUIRED_KEEPALIVE != $CONFIG_MATCH_KEEPALIVE"
 fi
 
 SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::' | head -n1)


### PR DESCRIPTION
- Add a dedicated parameter for the push of block-outside-dns, keeping compatibility with previous work.
- Fix an error with comp-lzo that was always present in the configuration even if the -z was not set
- Fix some typo in the ovpn_getclient script
