### PR TITLE
Push options need to be quoted

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -121,7 +121,7 @@ process_push_config() {
   local ovpn_push_config=''
   ovpn_push_config="$1"
   echo "Processing PUSH Config: '${ovpn_push_config}'"
-  [[ -n "$ovpn_push_config" ]] && echo "push $ovpn_push_config" >> "$TMP_PUSH_CONFIGFILE"
+  [[ -n "$ovpn_push_config" ]] && echo "push \"$ovpn_push_config\"" >> "$TMP_PUSH_CONFIGFILE"
 }
 
 process_extra_config() {

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -346,7 +346,7 @@ EOF
 if [ "${OVPN_DISABLE_PUSH_BLOCK_DNS}" == "1" ]; then
   echo "Disable default push of 'block-outside-dns'"
 else
-  process_push_config "\"block-outside-dns\""
+  process_push_config "block-outside-dns"
 fi
 
 [ -n "$OVPN_TLS_CIPHER" ] && echo "tls-cipher $OVPN_TLS_CIPHER" >> "$conf"
@@ -359,7 +359,7 @@ fi
 [ -n "${OVPN_FRAGMENT:-}" ] && echo "fragment $OVPN_FRAGMENT" >> "$conf"
 
 [ "$OVPN_DNS" == "1" ] && for i in "${OVPN_DNS_SERVERS[@]}"; do
-  process_push_config "\"dhcp-option DNS $i\""
+  process_push_config "dhcp-option DNS $i"
 done
 
 # Append route commands

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -346,7 +346,7 @@ EOF
 if [ "${OVPN_DISABLE_PUSH_BLOCK_DNS}" == "1" ]; then
   echo "Disable default push of 'block-outside-dns'"
 else
-  process_push_config "block-outside-dns"
+  process_push_config "\"block-outside-dns\""
 fi
 
 [ -n "$OVPN_TLS_CIPHER" ] && echo "tls-cipher $OVPN_TLS_CIPHER" >> "$conf"
@@ -359,7 +359,7 @@ fi
 [ -n "${OVPN_FRAGMENT:-}" ] && echo "fragment $OVPN_FRAGMENT" >> "$conf"
 
 [ "$OVPN_DNS" == "1" ] && for i in "${OVPN_DNS_SERVERS[@]}"; do
-  process_push_config "dhcp-option DNS $i"
+  process_push_config "\"dhcp-option DNS $i\""
 done
 
 # Append route commands

--- a/test/tests/conf_options/container.sh
+++ b/test/tests/conf_options/container.sh
@@ -47,23 +47,23 @@ CONFIG_MATCH_TOPOLOGY=$(busybox grep 'topology subnet' /etc/openvpn/openvpn.conf
 
 ## Tests for push config
 # 7. push route
-CONFIG_REQUIRED_PUSH_ROUTE="^push route 172.22.22.0 255.255.255.0"
-CONFIG_MATCH_PUSH_ROUTE=$(busybox grep 'push route 172.22.22.0 255.255.255.0' /etc/openvpn/openvpn.conf)
+CONFIG_REQUIRED_PUSH_ROUTE='^push "route 172.22.22.0 255.255.255.0"'
+CONFIG_MATCH_PUSH_ROUTE=$(busybox grep 'push "route 172.22.22.0 255.255.255.0"' /etc/openvpn/openvpn.conf)
 
 ## Test for default
 # 8. Should see default route if none provided
-CONFIG_REQUIRED_DEFAULT_ROUTE="^route 192.168.254.0 255.255.255.0"
+CONFIG_REQUIRED_DEFAULT_ROUTE='^route 192.168.254.0 255.255.255.0'
 CONFIG_MATCH_DEFAULT_ROUTE=$(busybox grep 'route 192.168.254.0 255.255.255.0' /etc/openvpn/openvpn.conf)
 
 # 9. Should see a push of 'block-outside-dns' by default
-CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS="^push block-outside-dns"
-CONFIG_MATCH_BLOCK_OUTSIDE_DNS=$(busybox grep 'push block-outside-dns' /etc/openvpn/openvpn.conf)
+CONFIG_REQUIRED_BLOCK_OUTSIDE_DNS='^push "block-outside-dns"'
+CONFIG_MATCH_BLOCK_OUTSIDE_DNS=$(busybox grep 'push "block-outside-dns"' /etc/openvpn/openvpn.conf)
 
 # 10. Should see a push of 'dhcp-option DNS' by default
-CONFIG_REQUIRED_DEFAULT_DNS_1="^push dhcp-option DNS 8.8.8.8"
-CONFIG_MATCH_DEFAULT_DNS_1=$(busybox grep 'push dhcp-option DNS 8.8.8.8' /etc/openvpn/openvpn.conf)
-CONFIG_REQUIRED_DEFAULT_DNS_2="^push dhcp-option DNS 8.8.4.4"
-CONFIG_MATCH_DEFAULT_DNS_2=$(busybox grep 'push dhcp-option DNS 8.8.4.4' /etc/openvpn/openvpn.conf)
+CONFIG_REQUIRED_DEFAULT_DNS_1='^push "dhcp-option DNS 8.8.8.8"'
+CONFIG_MATCH_DEFAULT_DNS_1=$(busybox grep 'push "dhcp-option DNS 8.8.8.8"' /etc/openvpn/openvpn.conf)
+CONFIG_REQUIRED_DEFAULT_DNS_2='^push "dhcp-option DNS 8.8.4.4"'
+CONFIG_MATCH_DEFAULT_DNS_2=$(busybox grep 'push "dhcp-option DNS 8.8.4.4"' /etc/openvpn/openvpn.conf)
 
 ## Test for keepalive
 # 11. keepalive config


### PR DESCRIPTION
In OpenVPN 2.4 this is required, but it's also in the the man page; "Note that option must be enclosed in double quotes ("")." I couldn't get OpenVPN to start without adding the quotes, so this would make it future-proof but also bring it in to line with the official documentation.