### PR TITLE
Defaults easy_rsa CRL next update to 3650 days

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ ENV EASYRSA /usr/share/easy-rsa
 ENV EASYRSA_PKI $OPENVPN/pki
 ENV EASYRSA_VARS_FILE $OPENVPN/vars
 
+# Prevents refused client connection because of an expired CRL
+ENV EASYRSA_CRL_DAYS 3650
+
 VOLUME ["/etc/openvpn"]
 
 # Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,9 @@ ENV EASYRSA /usr/share/easy-rsa
 ENV EASYRSA_PKI $OPENVPN/pki
 ENV EASYRSA_VARS_FILE $OPENVPN/vars
 
+# Prevents refused client connection because of an expired CRL
+ENV EASYRSA_CRL_DAYS 3650
+
 VOLUME ["/etc/openvpn"]
 
 # Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`


### PR DESCRIPTION
Proposed fix for #274, and accompanying test.

>  set the env var `EASYRSA_CRL_DAYS` to 3650 days by default, meaning that CRLs will outlive the CA (if easy RSA CA validity hasn't been set beyond the default ten years)
