### PR TITLE
Adding support for building an aarch64 image on dockerhub (x86)

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,9 +1,11 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
 # Smallest base image
-FROM aarch64/alpine:3.5
+FROM docker.io/project31/aarch64-alpine-qemu:3.5-6
 
-MAINTAINER Kyle Manna <kyle@kylemanna.com>
+RUN [ "cross-build-start" ]
+
+MAINTAINER Kurt Stam <kurt.stam@redhat.com>
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
@@ -32,3 +34,5 @@ RUN chmod a+x /usr/local/bin/*
 
 # Add support for OTP authentication using a PAM module
 ADD ./otp/openvpn /etc/pam.d/
+
+RUN [ "cross-build-end" ]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,14 +1,12 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
 # Smallest base image
-FROM docker.io/project31/aarch64-alpine-qemu:3.5-6
+FROM alpine:latest
 
-RUN [ "cross-build-start" ]
+MAINTAINER Kyle Manna <kyle@kylemanna.com>
 
-MAINTAINER Kurt Stam <kurt.stam@redhat.com>
-
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
-    echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
+# Testing: pamtester
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
     apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
@@ -34,5 +32,3 @@ RUN chmod a+x /usr/local/bin/*
 
 # Add support for OTP authentication using a PAM module
 ADD ./otp/openvpn /etc/pam.d/
-
-RUN [ "cross-build-end" ]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ a corresponding [Digital Ocean Community Tutorial](http://bit.ly/1AGUZkq).
 
 #### Upstream Links
 
-* Docker Registry @ [kylemanna/openvpn](https://hub.docker.com/r/kylemanna/openvpn/)
-* GitHub @ [kylemanna/docker-openvpn](https://github.com/kylemanna/docker-openvpn)
+* Docker Registry @ [project31/aarch64-docker-openvpn](https://hub.docker.com/r/project31/aarch64-docker-openvpn/)
+* GitHub @ [kurtstam/docker-openvpn](https://github.com/KurtStam/docker-openvpn/tree/aarch64)
 
 ## Quick Start
 
@@ -30,20 +30,23 @@ a corresponding [Digital Ocean Community Tutorial](http://bit.ly/1AGUZkq).
   private key used by the newly generated certificate authority.
 
         docker volume create --name $OVPN_DATA
-        docker run -v $OVPN_DATA:/etc/openvpn --rm kylemanna/openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
-        docker run -v $OVPN_DATA:/etc/openvpn --rm -it kylemanna/openvpn ovpn_initpki
+
+Make sure to update the public url (-u) and the nameservers (-n) in the following statement
+
+        docker run -v $OVPN_DATA:/etc/openvpn --rm project31/aarch64-docker-openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM -n 192.168.1.1 -n 8.8.8.8
+        docker run -v $OVPN_DATA:/etc/openvpn --rm -it project31/aarch64-docker-openvpn ovpn_initpki
 
 * Start OpenVPN server process
 
-        docker run -v $OVPN_DATA:/etc/openvpn -d -p 1194:1194/udp --cap-add=NET_ADMIN kylemanna/openvpn
+        docker run -v $OVPN_DATA:/etc/openvpn -d -p 1194:1194/udp --cap-add=NET_ADMIN project31/aarch64-docker-openvpn
 
 * Generate a client certificate without a passphrase
 
-        docker run -v $OVPN_DATA:/etc/openvpn --rm -it kylemanna/openvpn easyrsa build-client-full CLIENTNAME nopass
+        docker run -v $OVPN_DATA:/etc/openvpn --rm -it project31/aarch64-docker-openvpn easyrsa build-client-full CLIENTNAME nopass
 
 * Retrieve the client configuration with embedded certificates
 
-        docker run -v $OVPN_DATA:/etc/openvpn --rm kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
+        docker run -v $OVPN_DATA:/etc/openvpn --rm project31/aarch64-docker-openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
 
 ## Next Steps
 
@@ -68,7 +71,7 @@ If you prefer to use `docker-compose` please refer to the [documentation](docs/d
 
 * Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
 
-        docker run -v $OVPN_DATA:/etc/openvpn -p 1194:1194/udp --privileged -e DEBUG=1 kylemanna/openvpn
+        docker run -v $OVPN_DATA:/etc/openvpn -p 1194:1194/udp --privileged -e DEBUG=1 project31/aarch64-docker-openvpn
 
 * Test using a client that has openvpn installed correctly
 
@@ -86,7 +89,7 @@ If you prefer to use `docker-compose` please refer to the [documentation](docs/d
 
 ## How Does It Work?
 
-Initialize the volume container using the `kylemanna/openvpn` image with the
+Initialize the volume container using the `project31/aarch64-docker-openvpn` image with the
 included scripts to automatically generate:
 
 - Diffie-Hellman parameters


### PR DESCRIPTION
Patch for #287

Don't merge - if accepted it should stay on an aarch64 branch, unless we can parameterize the build using https://github.com/fabric8io-images/fish-pepper. 