### PR TITLE
docs: properly escape CONTRIBUTING markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ In an effort to not repeat bugs (and break less popular features), unit tests ar
 The style of the repo follows that of the Linux kernel, in particular:
 
 * Pull requests should be rebased to small atomic commits so that the merged history is more coherent
-* The subject of the commit should be in the form "<subsystem>: <subject>"
+* The subject of the commit should be in the form "`<subsystem>: <subject>`"
 * More details in the body
 * Match surrounding coding style (line wrapping, spaces, etc)
 


### PR DESCRIPTION
This PR fixes an escaping issue in the CONTRIBUTING.md markdown file that causes github not to render the suggested title format for commits.