### PR TITLE
systemd: reduce container privilege by whitelisting NET_ADMIN capability

### DIFF
--- a/init/docker-openvpn@.service
+++ b/init/docker-openvpn@.service
@@ -64,7 +64,7 @@ ExecStartPre=-/usr/bin/docker pull $IMG
 ExecStartPre=/bin/sh -c 'test -z "$IP6_PREFIX" && exit 0; sysctl net.ipv6.conf.all.forwarding=1'
 
 # Main process
-ExecStart=/usr/bin/docker run --rm --privileged -v ${DATA_VOL}:/etc/openvpn --name ${NAME} -p ${PORT} ${IMG} ovpn_run $ARGS
+ExecStart=/usr/bin/docker run --rm --cap-add=NET_ADMIN -v ${DATA_VOL}:/etc/openvpn --name ${NAME} -p ${PORT} ${IMG} ovpn_run $ARGS
 
 # IPv6: Add static route for IPv6 after it starts up
 ExecStartPost=/bin/sh -c 'test -z "${IP6_PREFIX}" && exit 0; sleep 1; ip route replace ${IP6_PREFIX} via $(docker inspect -f "{{ .NetworkSettings.GlobalIPv6Address }}" $NAME ) dev docker0'


### PR DESCRIPTION
The `--privileged` flag grants all capabilities to the container, and breaks some of the cgroups isolations that docker containers typically enjoy.  This is heavy handed for the typical user, who just wants the container to act as a gateway to the internet (and not as a general access point the host, akin to ssh).  I think it's worth considering narrowing the scope of privilege granted to openvpn, especially given its likelihood as a target for attackers.

I don't believe openvpn requires any capabilities that aren't covered by `NET_ADMIN`, which itself is pretty generous (see [capabilities(7)](http://man7.org/linux/man-pages/man7/capabilities.7.html)).  Removing `--privileged` also reduces the collection of devices exposed to the container, although to be frank, the documentation is lacking here.

I've tested this on my UDP-based setup on CoreOS, but I'm happy to test additional use cases and discuss the pros/cons of this PR.