### PR TITLE
Dockerfile: Removed forced UDP from EXPOSE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV EASYRSA_CRL_DAYS 3650
 VOLUME ["/etc/openvpn"]
 
 # Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`
-EXPOSE 1194/udp
+EXPOSE 1194
 
 CMD ["ovpn_run"]
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,7 +23,7 @@ ENV EASYRSA_CRL_DAYS 3650
 VOLUME ["/etc/openvpn"]
 
 # Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`
-EXPOSE 1194/udp
+EXPOSE 1194
 
 CMD ["ovpn_run"]
 


### PR DESCRIPTION
The protocol enforcing is now working correctly in the latest Docker versions.
That means, if you define the protocol inside the Dockerfile, you cannot overwrite it from 'docker run' command, it'll be simply ignored.
However if you don't define the protocol inside the image, then the 'docker run' command will be able define the protocol.