### PR TITLE
Use fixed openvpn version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,23 @@ MAINTAINER Kyle Manna <kyle@kylemanna.com>
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    apk add --update iptables bash easy-rsa google-authenticator pamtester && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
+
+ENV OPENVPN_VERSION 2.4.3
+ENV OPENVPN_GPG=6D04F8F1B0173111F499795E29584D9F40864578
+
+RUN apk add --no-cache gnupg g++ linux-headers openssl-dev lzo-dev linux-pam-dev make && \
+    wget https://swupdate.openvpn.org/community/releases/openvpn-${OPENVPN_VERSION}.tar.gz -P /tmp/ && \
+    wget https://swupdate.openvpn.org/community/releases/openvpn-${OPENVPN_VERSION}.tar.gz.asc -P /tmp/ && \
+    gpg --keyserver keys.gnupg.net --recv-keys ${OPENVPN_GPG} && \
+    gpg --batch --verify /tmp/openvpn-${OPENVPN_VERSION}.tar.gz.asc /tmp/openvpn-${OPENVPN_VERSION}.tar.gz && \
+    tar xzf /tmp/openvpn-${OPENVPN_VERSION}.tar.gz && \
+    cd /tmp/openvpn-${OPENVPN_VERSION} && ./configure && make -j 9 && \
+    cd /tmp/openvpn-${OPENVPN_VERSION}/src/plugins/auth-pam && make && \
+    cd /tmp/openvpn-${OPENVPN_VERSION} && make install && mkdir -p /usr/lib/openvpn/plugins/ && cp /tmp/openvpn-${OPENVPN_VERSION}/src/plugins/auth-pam/.libs/openvpn-plugin-auth-pam.so /usr/lib/openvpn/plugins/ && \
+    apk del gnupg g++ make && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 
 # Needed by scripts


### PR DESCRIPTION
Ensures installed version on openvpn without relying on repositories (https://security.archlinux.org/ASA-201706-27). 
Unfortunately I had problems in verifying gpg signature, so I used my previously created SHA-256 validation. With help I could try to rewrite to gpg, because it's published officially, and SHA I calculated myself.
Fixing alpine version is not required, but I did it out of habit.