### PR TITLE
Fix hardcoded ovpn port in ovpn_genconfig, now it uses OVPN_PORT vari…

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -331,8 +331,8 @@ persist-key
 persist-tun
 
 proto $OVPN_PROTO
-# Rely on Docker to do port mapping, internally always 1194
-port 1194
+# Rely on Docker to do port mapping, internally always $OVPN_PORT
+port $OVPN_PORT
 dev $OVPN_DEVICE$OVPN_DEVICEN
 status /tmp/openvpn-status.log
 


### PR DESCRIPTION
I found this issue trying to use a non-standard port.

Easy to change the port in the file, but the script is doing it for other variables like protocol or keepalive.