### PR TITLE
Fix ovpn_genconfig script to work in arm architecture

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -178,13 +178,13 @@ while getopts ":a:e:E:C:T:r:s:du:bcp:n:k:DNm:f:tz2" opt; do
             OVPN_AUTH="$OPTARG"
             ;;
         e)
-            mapfile -t TMP_EXTRA_SERVER_CONFIG < <(echo "$OPTARG")
+            mapfile -t TMP_EXTRA_SERVER_CONFIG <<< "$OPTARG"
             for i in "${TMP_EXTRA_SERVER_CONFIG[@]}"; do
               OVPN_EXTRA_SERVER_CONFIG+=("$i")
             done
             ;;
         E)
-            mapfile -t TMP_EXTRA_CLIENT_CONFIG < <(echo "$OPTARG")
+            mapfile -t TMP_EXTRA_CLIENT_CONFIG <<< "$OPTARG"
             for i in "${TMP_EXTRA_CLIENT_CONFIG[@]}"; do
               OVPN_EXTRA_CLIENT_CONFIG+=("$i")
             done
@@ -196,7 +196,7 @@ while getopts ":a:e:E:C:T:r:s:du:bcp:n:k:DNm:f:tz2" opt; do
             OVPN_TLS_CIPHER="$OPTARG"
             ;;
         r)
-            mapfile -t TMP_ROUTES < <(echo "$OPTARG")
+            mapfile -t TMP_ROUTES <<< "$OPTARG"
             for i in "${TMP_ROUTES[@]}"; do
               OVPN_ROUTES+=("$i")
             done
@@ -218,13 +218,13 @@ while getopts ":a:e:E:C:T:r:s:du:bcp:n:k:DNm:f:tz2" opt; do
             OVPN_CLIENT_TO_CLIENT=1
             ;;
         p)
-            mapfile -t TMP_PUSH < <(echo "$OPTARG")
+            mapfile -t TMP_PUSH <<< "$OPTARG"
             for i in "${TMP_PUSH[@]}"; do
               OVPN_PUSH+=("$i")
             done
             ;;
         n)
-            mapfile -t TMP_DNS_SERVERS < <(echo "$OPTARG")
+            mapfile -t TMP_DNS_SERVERS <<< "$OPTARG"
             for i in "${TMP_DNS_SERVERS[@]}"; do
               OVPN_DNS_SERVERS+=("$i")
             done
@@ -299,9 +299,9 @@ if [ -f "$OVPN_ENV" ]; then
 fi
 
 # Save the current OVPN_ vars to the ovpn_env.sh file
-while read -r var; do
+(set | grep '^OVPN_') | while read -r var; do
   echo "declare -x $var"  >> "$OVPN_ENV"
-done < <(set | grep '^OVPN_')
+done
 
 conf=${OPENVPN:-}/openvpn.conf
 if [ -f "$conf" ]; then


### PR DESCRIPTION
Some changes to make this script to work in arm architecture.

This PR does not brake the amd64, but makes it easier to port this image to arm architecture.
To build this image for arm change the FROM image from alpine to arm32v6/alpine or multiarch/alpine:armhf-v3.7