### PR TITLE
ovpn_getclient: key-direction before tls-auth

### DIFF
--- a/bin/ovpn_getclient
+++ b/bin/ovpn_getclient
@@ -58,10 +58,10 @@ $(openssl x509 -in $EASYRSA_PKI/issued/${cn}.crt)
 <ca>
 $(cat $EASYRSA_PKI/ca.crt)
 </ca>
+key-direction 1
 <tls-auth>
 $(cat $EASYRSA_PKI/ta.key)
 </tls-auth>
-key-direction 1
 "
     elif [ "$mode" == "separated" ]; then
         echo "


### PR DESCRIPTION
NetworkManager seems to be ignoring the `key-direction` directive when
it is after the `tls-auth` key, leading to issues as #268.

Signed-off-by: w2ak <w2ak@users.noreply.github.com>