### PR TITLE
Create Dockerfile.armv7

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,0 +1,34 @@
+# Original credit: https://github.com/jpetazzo/dockvpn
+
+# Smallest base image
+FROM hypriot/rpi-alpine
+
+LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
+
+RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
+    echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
+
+# Needed by scripts
+ENV OPENVPN /etc/openvpn
+ENV EASYRSA /usr/share/easy-rsa
+ENV EASYRSA_PKI $OPENVPN/pki
+ENV EASYRSA_VARS_FILE $OPENVPN/vars
+
+# Prevents refused client connection because of an expired CRL
+ENV EASYRSA_CRL_DAYS 3650
+
+VOLUME ["/etc/openvpn"]
+
+# Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`
+EXPOSE 1194/udp
+
+CMD ["ovpn_run"]
+
+ADD ./bin /usr/local/bin
+RUN chmod a+x /usr/local/bin/*
+
+# Add support for OTP authentication using a PAM module
+ADD ./otp/openvpn /etc/pam.d/


### PR DESCRIPTION
Adding support for armv7 to make it compatible with most of Raspbian distributions. File is exactly the same as aarch64 but taking the base image from the hypriot guys, since it supports the build of it from an x86 machine. 

I am currently running this on a RPi3 with Raspbian 9 32 bits and works perfect.