### PR TITLE
[bug fix] pushing comp-lzo setting to avoid error

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -369,6 +369,12 @@ fi
   process_push_config "dhcp-option DNS $i"
 done
 
+if [ "$OVPN_COMP_LZO" == "0"]; then
+    process_push_config "comp-lzo no"
+  else
+    process_push_config "comp-lzo"
+fi
+
 [ ${#OVPN_PUSH[@]} -gt 0 ] && for i in "${OVPN_PUSH[@]}"; do
   process_push_config "$i"
 done


### PR DESCRIPTION
I faced the following problem: client would connect but cannot receive any traffic from VPN server.
Logs from the docker container yielded the following line
```
IP packet with unknown IP version=15 seen
```
this is a well-known problem when ```comp-lzo``` is disabled on the server but enabled on the client.
Some clients, like my router, has some predefined parameters for OpenVPN configuration and enabled compression can easily be there like in my situation.
So I edited .conf file on the server to push ```comp-lzo no``` setting.
This PR contains ```ovpn_genconfig``` edit which adds this push to the configuration according to OVPN_COMP_LZO set in parameters.
I had no chances to test the result because on Mac OS X ```test/run.sh``` refused to run with the following log:
```
$ test/run.sh kylemanna/openvpn
readlink: illegal option -- f
usage: readlink [-n] [file ...]
test/run.sh: line 25: declare: -A: invalid option
```
so be sure to test this PR although it's pretty straightforward.

Thanks for the awesome project @kylemanna ! 

