### PR TITLE
[bug fix] removes pushing 'comp-lzo' when it is enabled to avoid issues on Android

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -352,6 +352,7 @@ fi
 
 [ -n "${OVPN_CLIENT_TO_CLIENT:-}" ] && echo "client-to-client" >> "$conf"
 [ "$OVPN_COMP_LZO" == "1" ] && echo "comp-lzo" >> "$conf"
+[ "$OVPN_COMP_LZO" == "0" ] && echo "comp-lzo no" >> "$conf"
 
 [ -n "${OVPN_FRAGMENT:-}" ] && echo "fragment $OVPN_FRAGMENT" >> "$conf"
 

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -371,8 +371,6 @@ done
 
 if [ "$OVPN_COMP_LZO" == "0" ]; then
     process_push_config "comp-lzo no"
-  else
-    process_push_config "comp-lzo"
 fi
 
 [ ${#OVPN_PUSH[@]} -gt 0 ] && for i in "${OVPN_PUSH[@]}"; do


### PR DESCRIPTION
Issue #381 highlighted the problem on Android not working after pushing adaptive compression setting. Looks like we should not push any `comp-lzo` setting when we want it to be enabled. Still when we want it disabled we push `comp-lzo no`.