### PR TITLE
Added documentation for tap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ To enable Two Factor Authentication for clients (a.k.a. OTP) see [this document]
 We use `tun` mode, because it works on the widest range of devices.
 `tap` mode, for instance, does not work on Android, except if the device
 is rooted.
+To start OpenVPN in `tap` mode use the `-t` parameter behind the `ovpn_genconfig` command.
 
 The topology used is `net30`, because it works on the widest range of OS.
 `p2p`, for instance, does not work on Windows.


### PR DESCRIPTION
This adds an explanation how to start openvpn in tap mode to the readme.md documentation.

https://github.com/kylemanna/docker-openvpn/pull/59 added this function. Thought it would be helpfull to mention the ability to start openvpn in tap mode (needed it to get the broadcasting for game lobbies running).

Take care!

Tucura