### PR TITLE
Only include client-to-client directive if exact 1

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -350,7 +350,7 @@ fi
 [ -n "$OVPN_CIPHER" ] && echo "cipher $OVPN_CIPHER" >> "$conf"
 [ -n "$OVPN_AUTH" ] && echo "auth $OVPN_AUTH" >> "$conf"
 
-[ -n "${OVPN_CLIENT_TO_CLIENT:-}" ] && echo "client-to-client" >> "$conf"
+[ "$OVPN_CLIENT_TO_CLIENT" == "1"] && echo "client-to-client" >> "$conf"
 [ "$OVPN_COMP_LZO" == "1" ] && echo "comp-lzo" >> "$conf"
 
 [ -n "${OVPN_FRAGMENT:-}" ] && echo "fragment $OVPN_FRAGMENT" >> "$conf"


### PR DESCRIPTION
To be more consistent with the rest of the config behavior i propose this config value to be only applied if it's value is exactly 1. Otherwise it is opaque whether the config is applied or not. Providing a value of 0 to turn the config of results in turning it on.