### PR TITLE
extended client status for EXPIRED or other errors

### DIFF
--- a/bin/ovpn_listclients
+++ b/bin/ovpn_listclients
@@ -15,6 +15,8 @@ cd "$EASYRSA_PKI"
 
 if [ -e crl.pem ]; then
     cat ca.crt crl.pem > cacheck.pem
+else
+    cat ca.crt > cacheck.pem
 fi
 
 echo "name,begin,end,status"
@@ -26,20 +28,29 @@ for name in issued/*.crt; do
     name=${name%.crt}
     name=${name#issued/}
     if [ "$name" != "$OVPN_CN" ]; then
-    if [ -e crl.pem ]; then
-        if openssl verify -crl_check -CAfile cacheck.pem $path &> /dev/null; then
-	status="VALID"
+        # check for revocation or expiration
+        command="openssl verify -crl_check -CAfile cacheck.pem $path"
+        result=$($command)
+        if [ $(echo "$result" | wc -l) == 1 ] && [ "$(echo "$result" | grep ": OK")" ]; then
+            status="VALID"
         else
-	status="REVOKED"
+            result=$(echo "$result" | tail -n 1 | grep error | cut -d" " -f2)
+            case $result in
+                10)
+                    status="EXPIRED"
+                    ;;
+                23)
+                    status="REVOKED"
+                    ;;
+                *)
+                    status="INVALID"
+            esac
         fi
-    else
-        status="VALID"
     fi
 
-        echo "$name,$begin,$end,$status"
-    fi
+    echo "$name,$begin,$end,$status"
+
 done
 
-if [ -e crl.pem ]; then
-    rm cacheck.pem
-fi
+# Clean
+rm cacheck.pem

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -11,9 +11,11 @@ Note that some client software might be picky about which configuration format i
 
 ## Client List
 
-See an overview of the configured clients, including revocation status:
+See an overview of the configured clients, including revocation and expiration status:
 
     docker run --rm -it -v $OVPN_DATA:/etc/openvpn kylemanna/openvpn ovpn_listclients
+
+ The output is generated using `openssl verify`. Error codes from the verification process different from `X509_V_ERR_CERT_HAS_EXPIRED` or `X509_V_ERR_CERT_REVOKED` will show the status `INVALID`.
 
 ## Batch Mode
 


### PR DESCRIPTION
When requesting the client list, you now are able to see immediately if one client certificate is expired. In addition, I show an *INVALID* status, when `openssl verify` returns any other error. 

Before, even expired certs were displayed as being valid.