### PR TITLE
Forward DNS requests made to the vpn server

### DIFF
--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -39,6 +39,12 @@ function addArg {
 # this allows rules/routing to be altered by supplying this function
 # in an included file, such as ovpn_env.sh
 function setupIptablesAndRouting {
+    # this will forward DNS requests to the DNS server the container
+    # is using
+    if [ ! -z "${OVPN_DNS_IPTABLES_FORWARD}" ]; then
+      iptables -t nat -A PREROUTING -p udp --dport 53 -j DNAT --to ${OVPN_DNS_IPTABLES_FORWARD}
+    fi;
+
     iptables -t nat -C POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE || {
       iptables -t nat -A POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE
     }


### PR DESCRIPTION
I needed this in order to resolve my home network's domain names while connected to the VPN.  Having this forwarding rule allowed me to make DNS requests to the VPN server and have a hostname like `myhomecomputer.homedomain` resolve to the appropriate IP.

When `$OVPN_DNS_IPTABLES_FORWARD` is declared in `/etc/openvpn/ovpn_env.sh` (for example, `declare -x OVPN_DNS_IPTABLES_FORWARD=192.168.1.1:53`), add an iptables rule to forward DNS traffic to the specified host.

Please let me know if this is useful and any additional changes needed to be an acceptable patch.

Thanks!
