### PR TITLE
expose 1194/tcp aswell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV EASYRSA_CRL_DAYS 3650
 VOLUME ["/etc/openvpn"]
 
 # Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`
-EXPOSE 1194/udp
+EXPOSE 1194 1194/udp
 
 CMD ["ovpn_run"]
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,7 +23,7 @@ ENV EASYRSA_CRL_DAYS 3650
 VOLUME ["/etc/openvpn"]
 
 # Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`
-EXPOSE 1194/udp
+EXPOSE 1194 1194/udp
 
 CMD ["ovpn_run"]
 


### PR DESCRIPTION
The tcp should be exposed as well, since non docker runtime(e. g. rkt) can't expose ports on the fly