### PR TITLE
Update docker-compose debugging tips to include port publishing

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -73,5 +73,5 @@ docker-compose run --rm openvpn ovpn_revokeclient $CLIENTNAME remove
 * Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
 
 ```bash
-docker-compose run -e DEBUG=1 openvpn
+docker-compose run -e DEBUG=1 -p 1194:1194/udp openvpn
 ```


### PR DESCRIPTION
According to the documentation docker-compose run command does not create any of the ports specified in the service configuration. So published ports should be specified in run command, otherwise you wouldn't be able to connect to the openvpn server.