### PR TITLE
Use exec instead of run

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -56,7 +56,7 @@ docker-compose run --rm openvpn easyrsa build-client-full $CLIENTNAME nopass
 * Retrieve the client configuration with embedded certificates
 
 ```bash
-docker-compose run --rm openvpn ovpn_getclient $CLIENTNAME > $CLIENTNAME.ovpn
+docker-compose exec openvpn ovpn_getclient $CLIENTNAME > $CLIENTNAME.ovpn
 ```
 
 * Revoke a client certificate


### PR DESCRIPTION
Generated config is empty if using run --rm:
https://github.com/kylemanna/docker-openvpn/issues/211#issuecomment-275881876