### PR TITLE
add libqrencode for visualize OTP QR code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester libqrencode && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester libqrencode && \
+    apk add --no-cache openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester libqrencode && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester libqrencode && \
+    apk add --no-cache openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester libqrencode && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester libqrencode && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 


### PR DESCRIPTION
As described in https://github.com/kylemanna/docker-openvpn/blob/a20c63893e4d0ca3478dcf35d56f051364c03b26/docs/otp.md the QR code for setting up OTP should be displayed in the console. But with the existing Docker image, it fails because of missing `libqrencode` (config for client1 was already created):
```
# docker-compose run --rm openvpn ovpn_otp_user client1
Warning: pasting the following URL into your browser exposes the OTP secret to Google:
  https://www.google.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/client1@my.domain%3Fsecret%3DCHLE3J5FKTKGVA7SPD4AWOHQDY%26issuer%3Dmy.domain
Failed to use libqrencode to show QR code visually for scanning.
Consider typing the OTP secret into your app manually.
Your new secret key is: CHLE3J5FKTKGVA7SPD4AWOHQDY
Your verification code is 960244
Your emergency scratch codes are:
  80015658
  57312161
  61004568
  53071680
  85918237
```

After adding package `libqrencode`, the QR code is successfully display:
```
# docker-compose exec openvpn sh
/ # apk add libqrencode
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
(1/2) Installing libpng (1.6.35-r0)
(2/2) Installing libqrencode (4.0.2-r0)
Executing busybox-1.29.3-r10.trigger
OK: 22 MiB in 35 packages
/ # ovpn_otp_user client1
Warning: pasting the following URL into your browser exposes the OTP secret to Google:
  https://www.google.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/client1@my.domain%3Fsecret%3DCB6I26HPIUFND72H3545M5E3VY%26issuer%3Dmy.domain
#####################
<REMOVED QR CODE>
#####################
Your new secret key is: CB6I26HPIUFND72H3545M5E3VY
Your verification code is 051911
Your emergency scratch codes are:
  96586335
  31046827
  52710593
  19751604
  88245362
```

I also replaced `apk --update` with `apk --no-cache` because `--no-cache` it is more lightweight and therefore the recommended way.