### PR TITLE
Update topology in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ We use `tun` mode, because it works on the widest range of devices.
 `tap` mode, for instance, does not work on Android, except if the device
 is rooted.
 
-The topology used is `net30`, because it works on the widest range of OS.
+The topology used is `subnet`, because it works on the widest range of OS.
 `p2p`, for instance, does not work on Windows.
 
 The UDP server uses`192.168.255.0/24` for dynamic clients by default.


### PR DESCRIPTION
The topology that is put in the documentation as being the topology used in the OpenVPN implementation is wrong – `net30`. Actually, the `subnet` topology is used.