### PR TITLE
Adding tzdata and python2 apks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester tzdata && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester tzdata && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester tzdata python2 && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 


### PR DESCRIPTION
- tzdata is needed for the time zone change in docker to work. I'm using path mount: -v /etc/localtime:/etc/localtime:ro to set the time zone from the host. But without installing tzdata in docker this change is not applied.

- python2 is needed for the Duo Authenticator plugin to work inside the container - https://duo.com/docs/openvpn. I was able to build it once with additional packages: make gcc musl-dev using the documentation from the mentioned website and save it in the /etc/openvpn/duo directory. The problem is though each time I'm rebuilding docker image it's missing python2 package which is required for this plugin to work. 