### PR TITLE
Used exec instead of run -rm

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -48,24 +48,24 @@ docker-compose logs -f
 ```bash
 export CLIENTNAME="your_client_name"
 # with a passphrase (recommended)
-docker-compose run --rm openvpn easyrsa build-client-full $CLIENTNAME
+docker-compose exec openvpn easyrsa build-client-full $CLIENTNAME
 # without a passphrase (not recommended)
-docker-compose run --rm openvpn easyrsa build-client-full $CLIENTNAME nopass
+docker-compose exec openvpn easyrsa build-client-full $CLIENTNAME nopass
 ```
 
 * Retrieve the client configuration with embedded certificates
 
 ```bash
-docker-compose run --rm openvpn ovpn_getclient $CLIENTNAME > $CLIENTNAME.ovpn
+docker-compose exec openvpn ovpn_getclient $CLIENTNAME > $CLIENTNAME.ovpn
 ```
 
 * Revoke a client certificate
 
 ```bash
 # Keep the corresponding crt, key and req files.
-docker-compose run --rm openvpn ovpn_revokeclient $CLIENTNAME
+docker-compose exec openvpn ovpn_revokeclient $CLIENTNAME
 # Remove the corresponding crt, key and req files.
-docker-compose run --rm openvpn ovpn_revokeclient $CLIENTNAME remove
+docker-compose exec openvpn ovpn_revokeclient $CLIENTNAME remove
 ```
 
 ## Debugging Tips


### PR DESCRIPTION
Using docker-compose exec runs the command in the existing openvpn container, avoiding zombie containers being created and hanging around using up resources.
I'm not sure about the two initial setup commands.  You may be able to do the same there, but I don't have the resources to test.