### PR TITLE
do not validate OTP codes in google-authenticator when ovpn_otp_use…

### DIFF
--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -15,6 +15,15 @@ source "$OPENVPN/ovpn_env.sh"
 # Specify "nopass" as arg[2] to make the CA insecure (not recommended!)
 nopass=$1
 
+# Workaround to remove unharmful error until easy-rsa 3.0.7
+# https://github.com/OpenVPN/easy-rsa/issues/261
+if [ -f "$EASYRSA_PKI/safessl-easyrsa.cnf" ]; then
+  sed -i 's/^RANDFILE/#RANDFILE/g' $EASYRSA_PKI/safessl-easyrsa.cnf
+fi
+if [ -f "$EASYRSA_PKI/openssl-easyrsa.cnf" ]; then
+  sed -i 's/^RANDFILE/#RANDFILE/g' $EASYRSA_PKI/openssl-easyrsa.cnf
+fi
+
 # Provides a sufficient warning before erasing pre-existing files
 easyrsa init-pki
 

--- a/bin/ovpn_otp_user
+++ b/bin/ovpn_otp_user
@@ -28,6 +28,6 @@ if [ "$2" == "interactive" ]; then
     # Always use time base OTP otherwise storage for counters must be configured somewhere in volume
     google-authenticator --time-based --force -l "${1}@${OVPN_CN}" -s /etc/openvpn/otp/${1}.google_authenticator
 else
-    google-authenticator --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3 \
+    google-authenticator --no-confirm --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3 \
         -l "${1}@${OVPN_CN}" -s /etc/openvpn/otp/${1}.google_authenticator
 fi


### PR DESCRIPTION
…r is not running in interactive mode

This PR adds the `--no-confirm` flag to the `google-authenticator` call to generate  an OTP configuration if the ovpn_otp_user script is called without the `interactive` flag. 

See issue #499 