### PR TITLE
Temp fix for rsa randfile build error

### DIFF
--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -15,6 +15,15 @@ source "$OPENVPN/ovpn_env.sh"
 # Specify "nopass" as arg[2] to make the CA insecure (not recommended!)
 nopass=$1
 
+# Workaround to remove unharmful error until easy-rsa 3.0.7
+# https://github.com/OpenVPN/easy-rsa/issues/261
+if [ -f "$EASYRSA_PKI/safessl-easyrsa.cnf" ]; then
+  sed -i 's/^RANDFILE/#RANDFILE/g' $EASYRSA_PKI/safessl-easyrsa.cnf
+fi
+if [ -f "$EASYRSA_PKI/openssl-easyrsa.cnf" ]; then
+  sed -i 's/^RANDFILE/#RANDFILE/g' $EASYRSA_PKI/openssl-easyrsa.cnf
+fi
+
 # Provides a sufficient warning before erasing pre-existing files
 easyrsa init-pki
 


### PR DESCRIPTION
Fixes the build error seen in https://travis-ci.org/kylemanna/docker-openvpn/builds/567904783

- Workaround to remove unharmful error until easy-rsa 3.0.7
- https://github.com/OpenVPN/easy-rsa/issues/261

cc @Canuteson #500 