### PR TITLE
add and bring UP tap interface when operating in tap mode

### DIFF
--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -59,6 +59,13 @@ if [ ! -c /dev/net/tun ]; then
     mknod /dev/net/tun c 10 200
 fi
 
+if [ $OVPN_DEVICE == "tap" ]; then
+        if [ $(ip link show | grep -c $OVPN_DEVICE$OVPN_DEVICEN:) -eq 0 ]; then
+                openvpn --mktun --dev $OVPN_DEVICE$OVPN_DEVICEN
+        fi
+        ip link set $OVPN_DEVICE$OVPN_DEVICEN up
+fi
+
 if [ -d "$OPENVPN/ccd" ]; then
     addArg "--client-config-dir" "$OPENVPN/ccd"
 fi


### PR DESCRIPTION
Fixes the following behavior:
When using tap mode, a tapX device is created by openvpn when starting, this **device is not brought UP** and **remains** in state **DOWN**.

Fix:
In `ovpn_run`:
* `openvpn --mktun --dev $OVPN_DEVICE$OVPN_DEVICEN` is used to create a tap device if the device specified by `$OVPN_DEVICE$OVPN_DEVICEN` does not exist
* the specifed tap device (existing or new) is brought to state UP