### PR TITLE
remove remove_files function and second arg

### DIFF
--- a/bin/ovpn_revokeclient
+++ b/bin/ovpn_revokeclient
@@ -22,7 +22,6 @@ if [ -z "$EASYRSA_PKI" ]; then
 fi
 
 cn="$1"
-parm="$2"
 
 if [ ! -f "$EASYRSA_PKI/private/${cn}.key" ]; then
     echo "Unable to find \"${cn}\", please try again or generate the key first" >&2
@@ -37,25 +36,4 @@ revoke_client_certificate(){
     chmod 644 "$OPENVPN/crl.pem"
 }
 
-remove_files(){
-    rm -v "$EASYRSA_PKI/issued/${1}.crt"
-    rm -v "$EASYRSA_PKI/private/${1}.key"
-    rm -v "$EASYRSA_PKI/reqs/${1}.req"
-}
-
-case "$parm" in
-    "remove")
-        revoke_client_certificate "$cn"
-        remove_files "$cn"
-        ;;
-    "" | "keep")
-        revoke_client_certificate "$cn"
-        ;;
-    *)
-        echo "When revoking a client certificate, this script let you choose if you want to remove the corresponding crt, key and req files." >&2
-        echo "Pease note that the removal of those files is required if you want to generate a new client certificate using the revoked certificate's CN." >&2
-        echo "    1. keep (default): Keep the files." >&2
-        echo "    2. remove: Remove the files." >&2
-        echo "Please specify one of those options as second parameter." >&2
-        ;;
-esac
+revoke_client_certificate "$cn"


### PR DESCRIPTION
The last easy-rsa update (3.0.6) changed the behavior of "easyrsa revoke" by now moving the revoked certificate into another folder. As far as i can tell this behaviour is not optional, please correct me if i'm wrong. (https://github.com/OpenVPN/easy-rsa/pull/63)
Therefore this container doesn't need to delete the files anymore and the optional argument "remove/keep" becomes obsolete.