### PR TITLE
Add workaround for easyrsa issue

### DIFF
--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -18,6 +18,10 @@ nopass=$1
 # Provides a sufficient warning before erasing pre-existing files
 easyrsa init-pki
 
+# Work around an issue in easyrsa which may generate insecure CA certs
+# https://github.com/OpenVPN/easy-rsa/issues/261
+sed -i '/^RANDFILE\s*=.*$/d' /etc/openvpn/pki/openssl-easyrsa.cnf
+
 # CA always has a password for protection in event server is compromised. The
 # password is only needed to sign client/server certificates.  No password is
 # needed for normal OpenVPN operation.


### PR DESCRIPTION
Fixes #528. Easyrsa looks for a `.rnd` file that doesn't exist in `/etc/openvpn/pki`, causing an error to be displayed while building the CA, and possibly making CA certs insecure. 

This PR fixes that by removing the erroneous line in the .cnf prior to building the CA. 

Here is the easy-rsa issue https://github.com/OpenVPN/easy-rsa/issues/261

