### PR TITLE
Fixing the build

### DIFF
--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -18,6 +18,9 @@ nopass=$1
 # Provides a sufficient warning before erasing pre-existing files
 easyrsa init-pki
 
+# Create a random file for easyrsa rng
+dd if=/dev/urandom of=$EASYRSA_PKI/.rnd bs=256 count=1
+
 # CA always has a password for protection in event server is compromised. The
 # password is only needed to sign client/server certificates.  No password is
 # needed for normal OpenVPN operation.

--- a/bin/ovpn_otp_user
+++ b/bin/ovpn_otp_user
@@ -28,6 +28,6 @@ if [ "$2" == "interactive" ]; then
     # Always use time base OTP otherwise storage for counters must be configured somewhere in volume
     google-authenticator --time-based --force -l "${1}@${OVPN_CN}" -s /etc/openvpn/otp/${1}.google_authenticator
 else
-    google-authenticator --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3 \
+    google-authenticator --no-confirm --time-based --disallow-reuse --force --rate-limit=3 --rate-time=30 --window-size=3 \
         -l "${1}@${OVPN_CN}" -s /etc/openvpn/otp/${1}.google_authenticator
 fi

--- a/test/tests/revocation/run.sh
+++ b/test/tests/revocation/run.sh
@@ -22,7 +22,7 @@ docker run --rm -v $OVPN_DATA:/etc/openvpn -it -e "EASYRSA_BATCH=1" -e "EASYRSA_
 # Fire up the server.
 #
 sudo iptables -N DOCKER || echo 'Firewall already configured'
-sudo iptables -I FORWARD 1 -j DOCKER
+sudo iptables -I FORWARD 1 -j DOCKER || echo 'Forward already configured'
 docker run -d -v $OVPN_DATA:/etc/openvpn --cap-add=NET_ADMIN --privileged -p 1194:1194/udp --name $NAME $IMG
 
 


### PR DESCRIPTION
This PR includes work from others that have been fixing the build. The build was failing for the following reasons:
- google-authenticator otp needs to be in non-interactive mode
- duplicate iptables rule in revocation test needs to be caught
- random file needs to be created for easyrsa rng