### PR TITLE
Enable sudo for iptables so an on_connect script can set DNAT and for…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester sudo && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 
@@ -32,3 +32,6 @@ RUN chmod a+x /usr/local/bin/*
 
 # Add support for OTP authentication using a PAM module
 ADD ./otp/openvpn /etc/pam.d/
+
+# Allow Openvpn to modify iptables
+ADD ./etc/openvpn_iptables /etc/sudoers.d/openvpn_iptables

--- a/etc/openvpn_iptables
+++ b/etc/openvpn_iptables
@@ -1,0 +1,3 @@
+Defaults:nobody !requiretty
+
+nobody ALL = NOPASSWD: /sbin/iptables


### PR DESCRIPTION
…ward connections correctly.

I have an openvpn.conf running this patch with the following changes:
```
script-security 2
client-connect /etc/openvpn/on_connect.sh
```

With an on_connect.sh of:

```
#!/bin/bash

/usr/bin/sudo /sbin/iptables -t nat -A PREROUTING -p tcp --dport 80 -j DNAT --to-destination $ifconfig_pool_remote_ip
/usr/bin/sudo /sbin/iptables -t nat -A PREROUTING -p tcp --dport 443 -j DNAT --to-destination $ifconfig_pool_remote_ip

exit 0
```