### PR TITLE
bin/ovpn_initpki: Touch vars file before init-pki

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,35 @@
+# Original credit: https://github.com/jpetazzo/dockvpn
+
+# Smallest base image
+FROM arm32v7/alpine:latest
+
+LABEL maintainer="Chris Abella <abella@targzet.com>"
+
+# Testing: pamtester
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
+    ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
+
+# Needed by scripts
+ENV OPENVPN /etc/openvpn
+ENV EASYRSA /usr/share/easy-rsa
+ENV EASYRSA_PKI $OPENVPN/pki
+ENV EASYRSA_VARS_FILE $OPENVPN/vars
+
+# Prevents refused client connection because of an expired CRL
+ENV EASYRSA_CRL_DAYS 3650
+
+VOLUME ["/etc/openvpn"]
+
+# Internally uses port 1194/udp, remap using `docker run -p 443:1194/tcp`
+EXPOSE 1194/udp
+
+CMD ["ovpn_run"]
+
+ADD ./bin /usr/local/bin
+RUN chmod a+x /usr/local/bin/*
+
+# Add support for OTP authentication using a PAM module
+ADD ./otp/openvpn /etc/pam.d/

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -6,7 +6,8 @@ FROM arm32v7/alpine:latest
 LABEL maintainer="Chris Abella <abella@targzet.com>"
 
 # Testing: pamtester
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/latest-stable/community/" >> /etc/apk/repositories && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/latest-stable/main" >> /etc/apk/repositories && \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk add --update openvpn iptables bash easy-rsa openvpn-auth-pam google-authenticator pamtester && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \

--- a/bin/ovpn_initpki
+++ b/bin/ovpn_initpki
@@ -15,6 +15,10 @@ source "$OPENVPN/ovpn_env.sh"
 # Specify "nopass" as arg[2] to make the CA insecure (not recommended!)
 nopass=$1
 
+# EasyRSA 3.0.7 introduced checks for $EASYRSA_VARS_FILE existence
+# in the init-pki script
+touch $EASYRSA_VARS_FILE
+
 # Provides a sufficient warning before erasing pre-existing files
 easyrsa init-pki
 


### PR DESCRIPTION
EasyRSA 3.0.7 introduces a check for the existence of vars in the
vars_setup() function. '$ easyrsa init-pki' fails without first
creating the file. See the [OpenVPN commit]( https://github.com/OpenVPN/easy-rsa/commit/abaa2f57b48e218ac58ee6dc793f178aada31f82#diff-231cb43897d7aa2a98dfda5720c2b40f) for the exact change.