### PR TITLE
bin/ovpn_genconfig: push routes to clients

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -112,7 +112,7 @@ process_route_config() {
   # If user passed "0" skip this, assume no extra routes
   [[ "$ovpn_route_config" == "0" ]] && break;
   echo "Processing Route Config: '${ovpn_route_config}'"
-  [[ -n "$ovpn_route_config" ]] && echo "route $(getroute $ovpn_route_config)" >> "$TMP_ROUTE_CONFIGFILE"
+  [[ -n "$ovpn_route_config" ]] && echo "push \"route $(getroute $ovpn_route_config)\"" >> "$TMP_ROUTE_CONFIGFILE"
 }
 
 process_push_config() {


### PR DESCRIPTION
Hi,
I've noticed that the generated configuration file contains lines like to following, for pushed routes:
```
route 192.168.254.0 255.255.255.0
```

I think that the correct syntax is:
```
push "route 192.168.254.0 255.255.255.0"
```