### PR TITLE
Cleanup some tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you prefer to use `docker-compose` please refer to the [documentation](docs/d
 
 * Create an environment variable with the name DEBUG and value of 1 to enable debug output (using "docker -e").
 
-        docker run -v $OVPN_DATA:/etc/openvpn -p 1194:1194/udp --privileged -e DEBUG=1 kylemanna/openvpn
+        docker run -v $OVPN_DATA:/etc/openvpn -p 1194:1194/udp --cap-add=NET_ADMIN -e DEBUG=1 kylemanna/openvpn
 
 * Test using a client that has openvpn installed correctly
 

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -39,11 +39,11 @@ function addArg {
 # this allows rules/routing to be altered by supplying this function
 # in an included file, such as ovpn_env.sh
 function setupIptablesAndRouting {
-    iptables -t nat -C POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE || {
+    iptables -t nat -C POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE 2>/dev/null || {
       iptables -t nat -A POSTROUTING -s $OVPN_SERVER -o $OVPN_NATDEVICE -j MASQUERADE
     }
     for i in "${OVPN_ROUTES[@]}"; do
-        iptables -t nat -C POSTROUTING -s "$i" -o $OVPN_NATDEVICE -j MASQUERADE || {
+        iptables -t nat -C POSTROUTING -s "$i" -o $OVPN_NATDEVICE -j MASQUERADE 2>/dev/null || {
           iptables -t nat -A POSTROUTING -s "$i" -o $OVPN_NATDEVICE -j MASQUERADE
         }
     done

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -87,13 +87,18 @@ fi
 
 ip -6 route show default 2>/dev/null
 if [ $? = 0 ]; then
-    echo "Enabling IPv6 Forwarding"
-    # If this fails, ensure the docker container is run with --privileged
-    # Could be side stepped with `ip netns` madness to drop privileged flag
+    echo "Checking IPv6 Forwarding"
+    if [ "$(</proc/sys/net/ipv6/conf/all/disable_ipv6)" != "0" ]; then
+        echo "Sysctl error for disable_ipv6, please run docker with '--sysctl net.ipv6.conf.all.disable_ipv6=0'"
+    fi
 
-    sysctl -w net.ipv6.conf.all.disable_ipv6=0 || echo "Failed to enable IPv6 support"
-    sysctl -w net.ipv6.conf.default.forwarding=1 || echo "Failed to enable IPv6 Forwarding default"
-    sysctl -w net.ipv6.conf.all.forwarding=1 || echo "Failed to enable IPv6 Forwarding"
+    if [ "$(</proc/sys/net/ipv6/conf/default/forwarding)" != "1" ]; then
+        echo "Sysctl error for default forwarding, please run docker with '--sysctl net.ipv6.conf.default.forwarding=1'"
+    fi
+
+    if [ "$(</proc/sys/net/ipv6/conf/all/forwarding)" != "1" ]; then
+        echo "Sysctl error for all forwarding, please run docker with '--sysctl net.ipv6.conf.all.forwarding=1'"
+    fi
 fi
 
 echo "Running 'openvpn ${ARGS[@]} ${USER_ARGS[@]}'"

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -17,4 +17,4 @@ The [`ovpn_genconfig`](/bin/ovpn_genconfig) script is intended for simple config
 
 * Start the server with:
 
-        docker run -v $PWD:/etc/openvpn -d -p 1194:1194/udp --privileged kylemanna/openvpn
+        docker run -v $PWD:/etc/openvpn -d -p 1194:1194/udp --cap-add=NET_ADMIN kylemanna/openvpn

--- a/docs/tcp.md
+++ b/docs/tcp.md
@@ -21,7 +21,7 @@ specified protocol, adjust the mapping appropriately:
 ## Running a Second Fallback TCP Container
 Instead of choosing between UDP and TCP, you can use both. A single instance of OpenVPN can only listen for a single protocol on a single port, but this image makes it easy to run two instances simultaneously. After building, configuring, and starting a standard container listening for UDP traffic on 1194, you can start a second container listening for tcp traffic on port 443:
 
-    docker run -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tcp --privileged kylemanna/openvpn ovpn_run --proto tcp
+    docker run -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tcp --cap-add=NET_ADMIN kylemanna/openvpn ovpn_run --proto tcp
 
 `ovpn_run` will load all the values from the default config file, and `--proto tcp` will override the protocol setting.
 

--- a/test/client/wait-for-connect.sh
+++ b/test/client/wait-for-connect.sh
@@ -5,7 +5,8 @@ set -e
 
 OPENVPN_CONFIG=${1:-/client/config.ovpn}
 
-# Run in background, rely on bash for job management
+# Run in background using bash job management, setup trap to clean-up
+trap "{ jobs -p | xargs -r kill; wait; }" EXIT
 openvpn --config "$OPENVPN_CONFIG" --management 127.0.0.1 9999 &
 
 # Spin waiting for interface to exist signifying connection
@@ -31,8 +32,6 @@ done
 
 if [ $i -ge $timeout ]; then
     echo "Error starting OpenVPN, i=$i, exiting."
-    exit 2;
+    exit 2
 fi
 
-# The show is over.
-kill %1

--- a/test/client/wait-for-connect.sh
+++ b/test/client/wait-for-connect.sh
@@ -5,6 +5,12 @@ set -e
 
 OPENVPN_CONFIG=${1:-/client/config.ovpn}
 
+# For some reason privileged mode creates the char device and cap-add=NET_ADMIN doesn't
+mkdir -p /dev/net
+if [ ! -c /dev/net/tun ]; then
+    mknod /dev/net/tun c 10 200
+fi
+
 # Run in background using bash job management, setup trap to clean-up
 trap "{ jobs -p | xargs -r kill; wait; }" EXIT
 openvpn --config "$OPENVPN_CONFIG" --management 127.0.0.1 9999 &
@@ -12,26 +18,33 @@ openvpn --config "$OPENVPN_CONFIG" --management 127.0.0.1 9999 &
 # Spin waiting for interface to exist signifying connection
 timeout=10
 for i in $(seq $timeout); do
+    # Allow to start-up
+    sleep 0.5
 
-    # Break when connected
-    #echo state | busybox nc 127.0.0.1 9999 | grep -q "CONNECTED,SUCCESS" && break;
+    # Use bash magic to open tcp socket on fd 3 and break when successful
+    exec 3<>/dev/tcp/127.0.0.1/9999 && break
+done
 
-    # Bash magic for tcp sockets
-    if exec 3<>/dev/tcp/127.0.0.1/9999; then
-        # Consume all header input
-        while read -t 0.1 <&3; do true; done
-        echo "state" >&3
-        read -t 1 <&3
-        echo -n $REPLY | grep -q "CONNECTED,SUCCESS" && break || true
-        exec 3>&-
-    fi
+if [ $i -ge $timeout ]; then
+    echo "Error connecting to OpenVPN mgmt interface, i=$i, exiting."
+    exit 2
+fi
 
-    # Else sleep
+# Consume all header input and echo, look for errors here
+while read -t 0.1 <&3; do echo $REPLY; done
+
+# Request state over mgmt interface
+timeout=10
+for i in $(seq $timeout); do
+    echo "state" >&3
+    state=$(head -n1 <&3)
+    echo -n "$state" | grep -q 'CONNECTED,SUCCESS' && break
     sleep 1
 done
 
 if [ $i -ge $timeout ]; then
-    echo "Error starting OpenVPN, i=$i, exiting."
-    exit 2
+    echo "Error connecting to OpenVPN, i=$i, exiting."
+    exit 3
 fi
 
+exec 3>&-

--- a/test/tests/basic/run.sh
+++ b/test/tests/basic/run.sh
@@ -22,8 +22,9 @@ docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_getclient $CLIENT | tee $CL
 docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_listclients | grep $CLIENT
 
 #
-# Fire up the server
+# Fire up the server and setup a trap to always clean it up
 #
+trap "{ jobs -p | xargs -r kill; wait; }" EXIT
 docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --privileged $IMG &
 
 #for i in $(seq 10); do
@@ -39,10 +40,6 @@ docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp -
 #
 docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
 
-#
-# Client either connected or timed out, kill server
-#
-kill %1
 
 #
 # Celebrate

--- a/test/tests/basic/run.sh
+++ b/test/tests/basic/run.sh
@@ -25,21 +25,19 @@ docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_listclients | grep $CLIENT
 # Fire up the server and setup a trap to always clean it up
 #
 trap "{ jobs -p | xargs -r kill; wait; }" EXIT
-docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --privileged $IMG &
+docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -e DEBUG --cap-add=NET_ADMIN $IMG &
 
-#for i in $(seq 10); do
-#    SERV_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}')
-#    test -n "$SERV_IP" && break
-#done
-#sed -ie s:SERV_IP:$SERV_IP:g config.ovpn
+for i in $(seq 10); do
+    SERV_IP_INTERNAL=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "ovpn-test" 2>/dev/null || true)
+    test -n "$SERV_IP_INTERNAL" && break
+    sleep 0.1
+done
+sed -i -e s:$SERV_IP:$SERV_IP_INTERNAL:g ${CLIENT_DIR}/config.ovpn
 
 #
-# Fire up a client in a container since openvpn is disallowed by Travis-CI, don't NAT
-# the host as it confuses itself:
-# "Incoming packet rejected from [AF_INET]172.17.42.1:1194[2], expected peer address: [AF_INET]10.240.118.86:1194"
+# Fire up a client in a container since openvpn is disallowed by Travis-CI
 #
-docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
-
+docker run --rm --cap-add=NET_ADMIN -e DEBUG --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
 
 #
 # Celebrate

--- a/test/tests/dual-proto/run.sh
+++ b/test/tests/dual-proto/run.sh
@@ -35,7 +35,8 @@ docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_listclients | grep $CLIENT_
 # Fire up the server
 #
 
-# run in shell bg to get logs
+# Run in shell bg to get logs, setup trap to clean-up
+trap "{ jobs -p | xargs -r kill; wait; }" EXIT
 docker run --name "ovpn-test-udp" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --privileged $IMG &
 docker run --name "ovpn-test-tcp" -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tcp --privileged $IMG ovpn_run --proto tcp &
 
@@ -47,10 +48,6 @@ docker run --name "ovpn-test-tcp" -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tc
 docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
 docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh "/client/config-tcp.ovpn"
 
-#
-# Client either connected or timed out, kill server
-#
-kill %1 %2
 
 #
 # Celebrate

--- a/test/tests/dual-proto/run.sh
+++ b/test/tests/dual-proto/run.sh
@@ -36,17 +36,30 @@ docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_listclients | grep $CLIENT_
 #
 
 # Run in shell bg to get logs, setup trap to clean-up
-trap "{ jobs -p | xargs -r kill; wait; }" EXIT
-docker run --name "ovpn-test-udp" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --cap-add=NET_ADMIN $IMG &
-docker run --name "ovpn-test-tcp" -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tcp --cap-add=NET_ADMIN $IMG ovpn_run --proto tcp &
+trap "{ jobs -p | xargs -r kill; wait; docker volume rm ${OVPN_DATA}; }" EXIT
+docker run --name "ovpn-test-udp" -v $OVPN_DATA:/etc/openvpn --rm --cap-add=NET_ADMIN -e DEBUG $IMG &
+docker run --name "ovpn-test-tcp" -v $OVPN_DATA:/etc/openvpn --rm --cap-add=NET_ADMIN -e DEBUG $IMG ovpn_run --proto tcp --port 443 &
+
+# Update configs
+for i in $(seq 10); do
+    SERV_IP_INTERNAL=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "ovpn-test-udp" 2>/dev/null || true)
+    test -n "$SERV_IP_INTERNAL" && break
+    sleep 0.1
+done
+sed -i -e s:$SERV_IP:$SERV_IP_INTERNAL:g $CLIENT_DIR/config.ovpn
+
+for i in $(seq 10); do
+    SERV_IP_INTERNAL=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "ovpn-test-tcp" 2>/dev/null || true)
+    test -n "$SERV_IP_INTERNAL" && break
+    sleep 0.1
+done
+sed -i -e s:$SERV_IP:$SERV_IP_INTERNAL:g $CLIENT_DIR/config-tcp.ovpn
 
 #
-# Fire up a clients in a containers since openvpn is disallowed by Travis-CI, don't NAT
-# the host as it confuses itself:
-# "Incoming packet rejected from [AF_INET]172.17.42.1:1194[2], expected peer address: [AF_INET]10.240.118.86:1194"
+# Fire up a clients in a containers since openvpn is disallowed by Travis-CI
 #
-docker run --rm --net=host --cap-add=NET_ADMIN --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
-docker run --rm --net=host --cap-add=NET_ADMIN --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh "/client/config-tcp.ovpn"
+docker run --rm --cap-add=NET_ADMIN -v $CLIENT_DIR:/client -e DEBUG $IMG /client/wait-for-connect.sh
+docker run --rm --cap-add=NET_ADMIN -v $CLIENT_DIR:/client -e DEBUG $IMG /client/wait-for-connect.sh "/client/config-tcp.ovpn"
 
 #
 # Celebrate

--- a/test/tests/dual-proto/run.sh
+++ b/test/tests/dual-proto/run.sh
@@ -37,17 +37,16 @@ docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_listclients | grep $CLIENT_
 
 # Run in shell bg to get logs, setup trap to clean-up
 trap "{ jobs -p | xargs -r kill; wait; }" EXIT
-docker run --name "ovpn-test-udp" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --privileged $IMG &
-docker run --name "ovpn-test-tcp" -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tcp --privileged $IMG ovpn_run --proto tcp &
+docker run --name "ovpn-test-udp" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --cap-add=NET_ADMIN $IMG &
+docker run --name "ovpn-test-tcp" -v $OVPN_DATA:/etc/openvpn --rm -p 443:1194/tcp --cap-add=NET_ADMIN $IMG ovpn_run --proto tcp &
 
 #
 # Fire up a clients in a containers since openvpn is disallowed by Travis-CI, don't NAT
 # the host as it confuses itself:
 # "Incoming packet rejected from [AF_INET]172.17.42.1:1194[2], expected peer address: [AF_INET]10.240.118.86:1194"
 #
-docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
-docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh "/client/config-tcp.ovpn"
-
+docker run --rm --net=host --cap-add=NET_ADMIN --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
+docker run --rm --net=host --cap-add=NET_ADMIN --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh "/client/config-tcp.ovpn"
 
 #
 # Celebrate

--- a/test/tests/otp/run.sh
+++ b/test/tests/otp/run.sh
@@ -49,6 +49,7 @@ grep 'reneg-sec 0' $CLIENT_DIR/config.ovpn || abort 'reneg-sec not set to 0 in c
 #
 # Fire up the server
 #
+trap "{ jobs -p | xargs -r kill; wait; }" EXIT
 docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --privileged $IMG &
 
 #for i in $(seq 10); do
@@ -64,10 +65,6 @@ docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp -
 #
 docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
 
-#
-# Client either connected or timed out, kill server
-#
-kill %1
 
 #
 # Celebrate

--- a/test/tests/otp/run.sh
+++ b/test/tests/otp/run.sh
@@ -50,21 +50,17 @@ grep 'reneg-sec 0' $CLIENT_DIR/config.ovpn || abort 'reneg-sec not set to 0 in c
 # Fire up the server
 #
 trap "{ jobs -p | xargs -r kill; wait; }" EXIT
-docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm -p 1194:1194/udp --privileged $IMG &
+docker run --name "ovpn-test" -v $OVPN_DATA:/etc/openvpn --rm --cap-add=NET_ADMIN $IMG &
 
-#for i in $(seq 10); do
-#    SERV_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}')
-#    test -n "$SERV_IP" && break
-#done
-#sed -ie s:SERV_IP:$SERV_IP:g $CLIENT_DIR/config.ovpn
+for i in $(seq 10); do
+    SERV_IP_INTERNAL=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}')
+    test -n "$SERV_IP_INTERNAL" && break
+done
+sed -ie s:$SERV_IP:$SERV_IP:g $CLIENT_DIR/config.ovpn
 
 #
-# Fire up a client in a container since openvpn is disallowed by Travis-CI, don't NAT
-# the host as it confuses itself:
-# "Incoming packet rejected from [AF_INET]172.17.42.1:1194[2], expected peer address: [AF_INET]10.240.118.86:1194"
-#
-docker run --rm --net=host --privileged --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
-
+# Fire up a client in a container since openvpn is disallowed by Travis-CI
+docker run --rm --net=host --cap-add=NET_ADMIN --volume $CLIENT_DIR:/client $IMG /client/wait-for-connect.sh
 
 #
 # Celebrate

--- a/test/tests/revocation/run.sh
+++ b/test/tests/revocation/run.sh
@@ -23,6 +23,8 @@ function finish {
     # Stop the server and clean up
     docker rm -f $NAME
     docker volume rm $OVPN_DATA
+    jobs -p | xargs -r kill
+    wait
 }
 trap finish EXIT
 

--- a/test/tests/revocation/run.sh
+++ b/test/tests/revocation/run.sh
@@ -54,7 +54,7 @@ docker exec -it $NAME bash -c "echo 'yes' | ovpn_revokeclient $CLIENT1"
 #
 # Test that openvpn client can't connect using $CLIENT1 config.
 #
-if docker run --rm -v $CLIENT_DIR:/client --cap-add=NET_ADMIN --privileged --net=host $IMG /client/wait-for-connect.sh; then
+if docker run --rm -v $CLIENT_DIR:/client --cap-add=NET_ADMIN --cap-add=NET_ADMIN --net=host $IMG /client/wait-for-connect.sh; then
     echo "Client was able to connect after revocation test #1." >&2
     exit 2
 fi
@@ -66,7 +66,7 @@ docker exec -it $NAME easyrsa build-client-full $CLIENT2 nopass
 docker exec -it $NAME ovpn_getclient $CLIENT2 > $CLIENT_DIR/config.ovpn
 docker exec -it $NAME bash -c "echo 'yes' | ovpn_revokeclient $CLIENT2"
 
-if docker run --rm -v $CLIENT_DIR:/client --cap-add=NET_ADMIN --privileged --net=host $IMG /client/wait-for-connect.sh; then
+if docker run --rm -v $CLIENT_DIR:/client --cap-add=NET_ADMIN --cap-add=NET_ADMIN --net=host $IMG /client/wait-for-connect.sh; then
     echo "Client was able to connect after revocation test #2." >&2
     exit 2
 fi
@@ -79,7 +79,7 @@ docker stop $NAME && docker start $NAME
 #
 # Test for failed connection using $CLIENT2 config again.
 #
-if docker run --rm -v $CLIENT_DIR:/client --cap-add=NET_ADMIN --privileged --net=host $IMG /client/wait-for-connect.sh; then
+if docker run --rm -v $CLIENT_DIR:/client --cap-add=NET_ADMIN --cap-add=NET_ADMIN --net=host $IMG /client/wait-for-connect.sh; then
     echo "Client was able to connect after revocation test #3." >&2
     exit 2
 fi


### PR DESCRIPTION
Localize a lot of the testing by dropping things like `--privileged` and `--net=host` to make testing safer and approach of least privilege.

* Drop `--net=host` everywhere - this terrorized my dev machine.
* Drop `--privileged` this isn't really needed other then messing with `sysctl` values. Warnings are printed now.
* Update docs so I never read of these things again.
* Attempt to tear-down tests slightly better. It's still a mess though.
* Silence `iptables` checks.
* Propagate `DEBUG` environment variable deeper to help debugging.