### PR TITLE
Fix doc to get "embedded certificates"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ a corresponding [Digital Ocean Community Tutorial](http://bit.ly/1AGUZkq).
 
 * Retrieve the client configuration with embedded certificates
 
-      docker run -v $OVPN_DATA:/etc/openvpn --rm kylemanna/openvpn ovpn_getclient CLIENTNAME > CLIENTNAME.ovpn
+      docker run -v $OVPN_DATA:/etc/openvpn --rm kylemanna/openvpn ovpn_getclient CLIENTNAME combined > CLIENTNAME.ovpn
 
 ## Next Steps
 


### PR DESCRIPTION
When following the doc to setup a server with a first client the config file provided was missing certificates.