### PR TITLE
feat: Update Dockerfile.aarch64 aarch64 not supported anymore

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,7 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
 # Smallest base image
-FROM aarch64/alpine:3.5
+FROM arm64v8/alpine:3.18.3
 
 LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 


### PR DESCRIPTION
Aarch64 group doesnt exist anymore on dockerhub