### PR TITLE
Add -i to both configuration/certificate generating commands

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -21,8 +21,8 @@ services:
 * Initialize the configuration files and certificates
 
 ```bash
-docker-compose run --rm openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM
-docker-compose run --rm openvpn ovpn_initpki
+docker-compose run --rm openvpn ovpn_genconfig -u udp://VPN.SERVERNAME.COM -i
+docker-compose run --rm openvpn ovpn_initpki -i
 ```
 
 * Fix ownership (depending on how to handle your backups, this may not be needed)


### PR DESCRIPTION
Without `-i`, the stdin wont be piped to the 2 containers and, while setting up the certificate, you'll get an error similar to this:
```136808030649672:error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt:crypto/evp/evp_enc.c:583:
136808030649672:error:0906A065:PEM routines:PEM_do_header:bad decrypt:crypto/pem/pem_lib.c:461:
```
Relevant issue: #148 